### PR TITLE
💥 Change dependencies check configuration location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Dependencies check configuration is moved from `javascript.dependenciesCheck` to `javascript.dependencies.check`.
+
 Features:
 
 - Implement `ProjectDependenciesUpdate` for JavaScript and TypeScript.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Apart from `build` and `publish`, other project-level commands are supported:
 - `cs init`: Runs `npm ci`, setting up the `node_modules` locally.
 - `cs lint`: Runs `npm run lint`.
 - `cs test`: Runs `npm run test`.
-- `cs dependencies check`: Uses `npm audit` to check dependencies for vulnerabilities. See the `javascript.dependenciesCheck` configuration for more options.
+- `cs dependencies check`: Uses `npm audit` to check dependencies for vulnerabilities. See the `javascript.dependencies.check` configuration for more options.
 - `cs dependencies update`: Uses [npm-check-updates](https://github.com/raineorshine/npm-check-updates) to update the `package.json` file, then run `npm update`.
 - `cs security check`: Uses [njsscan](https://github.com/ajinabraham/njsscan) to scan for common insecure code patterns.
 

--- a/src/configurations/typescript.ts
+++ b/src/configurations/typescript.ts
@@ -35,30 +35,30 @@ export type TypeScriptConfiguration = {
     };
 
     /**
-     * Configuration used when checking dependencies for vulnerabilities.
-     */
-    dependenciesCheck?: {
-      /**
-       * Whether to ignore vulnerabilities in dev dependencies.
-       */
-      skipDev?: boolean;
-
-      /**
-       * The minimum severity level of vulnerabilities to fail the check.
-       */
-      level?: 'low' | 'moderate' | 'high' | 'critical';
-
-      /**
-       * A list of vulnerabilities to allow.
-       * See: https://github.com/IBM/audit-ci#allowlisting
-       */
-      allowlist?: string[];
-    };
-
-    /**
      * Configuration related to JavaScript dependencies.
      */
     dependencies?: {
+      /**
+       * Configuration used when checking dependencies for vulnerabilities.
+       */
+      check?: {
+        /**
+         * Whether to ignore vulnerabilities in dev dependencies.
+         */
+        skipDev?: boolean;
+
+        /**
+         * The minimum severity level of vulnerabilities to fail the check.
+         */
+        level?: 'low' | 'moderate' | 'high' | 'critical';
+
+        /**
+         * A list of vulnerabilities to allow.
+         * See: https://github.com/IBM/audit-ci#allowlisting
+         */
+        allowlist?: string[];
+      };
+
       /**
        * Configuration related to the update of dependencies.
        */

--- a/src/functions/project-dependencies-check-javascript.spec.ts
+++ b/src/functions/project-dependencies-check-javascript.spec.ts
@@ -81,10 +81,8 @@ describe('ProjectDependenciesCheckForJavaScript', () => {
           language: 'javascript',
         },
         javascript: {
-          dependenciesCheck: {
-            skipDev: true,
-            level: 'moderate',
-            allowlist: ['foo'],
+          dependencies: {
+            check: { skipDev: true, level: 'moderate', allowlist: ['foo'] },
           },
         },
       },
@@ -116,7 +114,7 @@ describe('ProjectDependenciesCheckForJavaScript', () => {
           type: 'package',
           language: 'javascript',
         },
-        javascript: { dependenciesCheck: { level: '🚨' } },
+        javascript: { dependencies: { check: { level: '🚨' } } },
       },
       functions: [ProjectDependenciesCheckForJavaScript],
     }));

--- a/src/functions/project-dependencies-check-javascript.ts
+++ b/src/functions/project-dependencies-check-javascript.ts
@@ -31,9 +31,9 @@ const ALLOWED_VULNERABILITY_LEVELS: VulnerabilityLevel[] = [
 export class ProjectDependenciesCheckForJavaScript extends ProjectDependenciesCheck {
   async _call(context: WorkspaceContext): Promise<void> {
     const conf = context.asConfiguration<TypeScriptConfiguration>();
-    const level = conf.get('javascript.dependenciesCheck.level');
-    const skipDev = conf.get('javascript.dependenciesCheck.skipDev');
-    const allowlist = conf.get('javascript.dependenciesCheck.allowlist');
+    const level = conf.get('javascript.dependencies.check.level');
+    const skipDev = conf.get('javascript.dependencies.check.skipDev');
+    const allowlist = conf.get('javascript.dependencies.check.allowlist');
 
     if (level && !ALLOWED_VULNERABILITY_LEVELS.includes(level)) {
       throw new Error(`Invalid dependencies check level '${level}'.`);


### PR DESCRIPTION
This PR introduces a breaking change to improve configuration consistency: all dependency-related configuration is now under `javascript.dependencies`.

### Commits

- 💥 Change the location of configuration for dependencies checks
- 📝 Update documentation
- 📝 Update changelog