### PR TITLE
🔖 Prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.0 (2023-10-03)
+
 Breaking changes:
 
 - The `typescript.serviceContainerDockerfile` configuration has been removed and replaced by the `serviceContainer.buildFile` parameter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.12.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": "github:causa-io/workspace-module-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- The `typescript.serviceContainerDockerfile` configuration has been removed and replaced by the `serviceContainer.buildFile` parameter.
- The default `Dockerfile` for TypeScript service containers now supports an `NPM_TOKEN` secret (rather than a build argument) that will be passed as an environment variable during `npm ci` calls.

Features:

- The default `Dockerfile` for TypeScript service containers now reuses the npm cache across calls and builds.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.6.0