### PR TITLE
🔖 Prepare v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.1 (2023-11-07)
+
 Fixes:
 
 - Ensure the TypeScript decorator renderers are ordered, such that decorators are always listed in the same order in generated files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.12.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": "github:causa-io/workspace-module-typescript",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Ensure the TypeScript decorator renderers are ordered, such that decorators are always listed in the same order in generated files.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.7.1