### PR TITLE
🔖 Prepare v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.2 (2023-11-20)
+
 Fixes:
 
 - Set the UUID version of the generated `@IsUUID` decorator to `undefined`, as it cannot be known from the schema. This ensures the decorator is valid and can be used for arrays as well.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.12.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": "github:causa-io/workspace-module-typescript",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Set the UUID version of the generated `@IsUUID` decorator to `undefined`, as it cannot be known from the schema. This ensures the decorator is valid and can be used for arrays as well.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.7.2