### PR TITLE
🔖 Prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.8.0 (2024-01-23)
+
 Breaking changes:
 
 - The `@ApiProperty` decorators from code generation now produce OpenAPI 3.1-compatible specifications.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.12.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": "github:causa-io/workspace-module-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- The `@ApiProperty` decorators from code generation now produce OpenAPI 3.1-compatible specifications.
- OpenAPI generation for service containers now produce a specification marked with version `3.1.0`.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.8.0