### PR TITLE
🐛 Fix OpenAPI 3.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Fixes:
+
+- Do not set a class type in the `@ApiProperty` decorator when NestJS can infer it.
+- Explicitly set the type of string enums in generated ApiProperty decorators.
+
 ## v0.8.0 (2024-01-23)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/node": "^18.19.8",
         "@types/semver": "^7.5.6",
         "@types/uuid": "^9.0.7",
-        "@typescript-eslint/eslint-plugin": "^6.19.0",
+        "@typescript-eslint/eslint-plugin": "^6.19.1",
         "copyfiles": "^2.4.1",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -2188,16 +2188,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.0.tgz",
-      "integrity": "sha512-DUCUkQNklCQYnrBSSikjVChdc84/vMPDQSgJTHBZ64G9bA9w0Crc0rd2diujKbTdp6w2J47qkeHQLoi0rpLCdg==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.1.tgz",
+      "integrity": "sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.19.0",
-        "@typescript-eslint/type-utils": "6.19.0",
-        "@typescript-eslint/utils": "6.19.0",
-        "@typescript-eslint/visitor-keys": "6.19.0",
+        "@typescript-eslint/scope-manager": "6.19.1",
+        "@typescript-eslint/type-utils": "6.19.1",
+        "@typescript-eslint/utils": "6.19.1",
+        "@typescript-eslint/visitor-keys": "6.19.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -2223,16 +2223,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.0.tgz",
-      "integrity": "sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.1.tgz",
+      "integrity": "sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.19.0",
-        "@typescript-eslint/types": "6.19.0",
-        "@typescript-eslint/typescript-estree": "6.19.0",
-        "@typescript-eslint/visitor-keys": "6.19.0",
+        "@typescript-eslint/scope-manager": "6.19.1",
+        "@typescript-eslint/types": "6.19.1",
+        "@typescript-eslint/typescript-estree": "6.19.1",
+        "@typescript-eslint/visitor-keys": "6.19.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2252,13 +2252,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.0.tgz",
-      "integrity": "sha512-dO1XMhV2ehBI6QN8Ufi7I10wmUovmLU0Oru3n5LVlM2JuzB4M+dVphCPLkVpKvGij2j/pHBWuJ9piuXx+BhzxQ==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
+      "integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.0",
-        "@typescript-eslint/visitor-keys": "6.19.0"
+        "@typescript-eslint/types": "6.19.1",
+        "@typescript-eslint/visitor-keys": "6.19.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2269,13 +2269,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.0.tgz",
-      "integrity": "sha512-mcvS6WSWbjiSxKCwBcXtOM5pRkPQ6kcDds/juxcy/727IQr3xMEcwr/YLHW2A2+Fp5ql6khjbKBzOyjuPqGi/w==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.1.tgz",
+      "integrity": "sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.19.0",
-        "@typescript-eslint/utils": "6.19.0",
+        "@typescript-eslint/typescript-estree": "6.19.1",
+        "@typescript-eslint/utils": "6.19.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -2296,9 +2296,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.0.tgz",
-      "integrity": "sha512-lFviGV/vYhOy3m8BJ/nAKoAyNhInTdXpftonhWle66XHAtT1ouBlkjL496b5H5hb8dWXHwtypTqgtb/DEa+j5A==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
+      "integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -2309,13 +2309,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.0.tgz",
-      "integrity": "sha512-o/zefXIbbLBZ8YJ51NlkSAt2BamrK6XOmuxSR3hynMIzzyMY33KuJ9vuMdFSXW+H0tVvdF9qBPTHA91HDb4BIQ==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
+      "integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.0",
-        "@typescript-eslint/visitor-keys": "6.19.0",
+        "@typescript-eslint/types": "6.19.1",
+        "@typescript-eslint/visitor-keys": "6.19.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2366,17 +2366,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.0.tgz",
-      "integrity": "sha512-QR41YXySiuN++/dC9UArYOg4X86OAYP83OWTewpVx5ct1IZhjjgTLocj7QNxGhWoTqknsgpl7L+hGygCO+sdYw==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
+      "integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.19.0",
-        "@typescript-eslint/types": "6.19.0",
-        "@typescript-eslint/typescript-estree": "6.19.0",
+        "@typescript-eslint/scope-manager": "6.19.1",
+        "@typescript-eslint/types": "6.19.1",
+        "@typescript-eslint/typescript-estree": "6.19.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -2391,12 +2391,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.0.tgz",
-      "integrity": "sha512-hZaUCORLgubBvtGpp1JEFEazcuEdfxta9j4iUwdSAr7mEsYYAp3EAUyCZk3VEEqGj6W+AV4uWyrDGtrlawAsgQ==",
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
+      "integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.19.0",
+        "@typescript-eslint/types": "6.19.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -3908,9 +3908,9 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.640",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.640.tgz",
-      "integrity": "sha512-z/6oZ/Muqk4BaE7P69bXhUhpJbUM9ZJeka43ZwxsDshKtePns4mhBlh8bU5+yrnOnz3fhG82XLzGUXazOmsWnA==",
+      "version": "1.4.642",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.642.tgz",
+      "integrity": "sha512-M4+u22ZJGpk4RY7tne6W+APkZhnnhmAH48FNl8iEFK2lEgob+U5rUQsIqQhvAwCXYpfd3H20pHK/ENsCvwTbsA==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/node": "^18.19.8",
     "@types/semver": "^7.5.6",
     "@types/uuid": "^9.0.7",
-    "@typescript-eslint/eslint-plugin": "^6.19.0",
+    "@typescript-eslint/eslint-plugin": "^6.19.1",
     "copyfiles": "^2.4.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",

--- a/src/code-generation/renderers/openapi-renderer.spec.ts
+++ b/src/code-generation/renderers/openapi-renderer.spec.ts
@@ -123,7 +123,7 @@ describe('OpenApiRenderer', () => {
       /@ApiProperty\({\s*type: "string"\s*}\)\n\s+readonly myString/,
     );
     expect(actualCode).toMatch(
-      /@ApiProperty\({\s*enum: \["a", "b", "c"\]\s*}\)\n\s+readonly myEnum/,
+      /@ApiProperty\({\s*type: "string",\s*enum: \["a", "b", "c"\]\s*}\)\n\s+readonly myEnum/,
     );
     expect(actualCode).toMatch(
       /@ApiProperty\({\s*oneOf: \[\s*\{ type: "integer" \},\s*\{ type: "null" \}\s*\]\s*}\)\n\s+readonly myInt/,

--- a/src/code-generation/renderers/openapi-renderer.spec.ts
+++ b/src/code-generation/renderers/openapi-renderer.spec.ts
@@ -135,7 +135,7 @@ describe('OpenApiRenderer', () => {
       /@ApiProperty\({\s*type: "boolean"\s*}\)\n\s+readonly myBool/,
     );
     expect(actualCode).toMatch(
-      /@ApiProperty\({\s*oneOf: \[\{\s*\$ref: getSchemaPath\(MyClass\)\s*\}\]\s*}\)\n\s+readonly myClass/,
+      /@ApiProperty\(\{\s*(?!oneOf)\}\)\n\s+readonly myClass/,
     );
     expect(actualCode).toMatch(
       /@ApiProperty\(\{\s*oneOf: \[\{\s*\$ref: getSchemaPath\(MyClass3\)\s*\},\s*\{ type: "null" \}\]\s*\}\)\n\s+readonly myNullableClass/,
@@ -150,7 +150,7 @@ describe('OpenApiRenderer', () => {
       /@ApiProperty\({\s*type: "object",\s*additionalProperties: true\s*}\)\n\s+readonly myObjectWithAny/,
     );
     expect(actualCode).toMatch(
-      /@ApiProperty\(\{\s*type: "array",\s*items:\s*\{\s*oneOf: \[\{\s*\$ref: getSchemaPath\(MyClass2\)\s*\}\]\s*\},\s*\}\)\n\s+readonly myArrayOfClasses/,
+      /@ApiProperty\(\{\s*type: "array",\s*items:\s*\{\s*\$ref: getSchemaPath\(MyClass2\)\s*\}\s*\}\)\n\s+readonly myArrayOfClasses/,
     );
     expect(actualCode).toMatch(
       /@ApiProperty\(\{\s*type: "array",\s*items:\s*\{\s*oneOf: \[\{\s*type: "boolean"\s*\},\s*\{ type: "null" \}\s*\]\s*\},\s*\}\)\n\s+readonly myArrayOfNullables/,

--- a/src/code-generation/renderers/openapi-renderer.ts
+++ b/src/code-generation/renderers/openapi-renderer.ts
@@ -1,4 +1,4 @@
-import { EnumType, MapType, Sourcelike, Type, TypeKind } from 'quicktype-core';
+import { EnumType, MapType, Type, TypeKind } from 'quicktype-core';
 import { SourcelikeArray } from 'quicktype-core/dist/Source.js';
 import { TypeScriptDecorator } from '../decorator.js';
 import {
@@ -39,9 +39,13 @@ const TYPE_KIND_TO_JSONSCHEMA_TYPE: Partial<Record<TypeKind, string>> = {
  * This function is recursive, and will generate options for array types as well.
  *
  * @param type The type for which the decorator options should be generated.
+ * @param isArrayItem Whether the type is the item of an array.
  * @returns The source code for the decorator options.
  */
-function typeToDecoratorOptions(type: Type): SourcelikeArray {
+function typeToDecoratorOptions(
+  type: Type,
+  isArrayItem: boolean = false,
+): SourcelikeArray {
   const singleTypeInfo = getSingleType(type);
   if (!singleTypeInfo) {
     return [];
@@ -51,7 +55,7 @@ function typeToDecoratorOptions(type: Type): SourcelikeArray {
   const decoratorOptions: SourcelikeArray = [];
 
   if (isArray) {
-    const itemOptions = typeToDecoratorOptions(singleType);
+    const itemOptions = typeToDecoratorOptions(singleType, true);
     decoratorOptions.push(`type: 'array', `, 'items: { ', itemOptions, ' }, ');
   } else {
     const jsonSchemaType = TYPE_KIND_TO_JSONSCHEMA_TYPE[singleType.kind];
@@ -69,12 +73,14 @@ function typeToDecoratorOptions(type: Type): SourcelikeArray {
         decoratorOptions.push(`enum: ${JSON.stringify(cases)}, `);
         break;
       case 'class':
+        // If the type is not nullable and is not a nested item (i.e. in an array), NestJS will automatically infer the
+        // type and declare it using `allOf`. Other type information should not be added in the decorator.
+        if (!isNullable && !isArrayItem) {
+          return [];
+        }
+
         const typeName = singleType.getCombinedName();
-        const refOption: Sourcelike = `$ref: getSchemaPath(${typeName})`;
-        // If the type is nullable, `oneOf` will be added before returning the decorator options.
-        decoratorOptions.push(
-          isNullable ? refOption : ['oneOf: [{', refOption, '}]'],
-        );
+        decoratorOptions.push(`$ref: getSchemaPath(${typeName})`);
         break;
       case 'map':
         const additionalProperties = (

--- a/src/code-generation/renderers/openapi-renderer.ts
+++ b/src/code-generation/renderers/openapi-renderer.ts
@@ -30,6 +30,8 @@ const TYPE_KIND_TO_JSONSCHEMA_TYPE: Partial<Record<TypeKind, string>> = {
   double: 'number',
   bool: 'boolean',
   map: 'object',
+  // Only string enums are supported by Quicktype.
+  enum: 'string',
 };
 
 /**


### PR DESCRIPTION
This fixes issues with decorator code generation for OpenAPI documentation, namely:

- Improve enums by adding the `type: string` information.
- Fix properties with a class type, to which NestJS already automatically adds `allOf:` information.

### Commits

- ⬆️ Upgrade dependencies
- ✨ Explicitely set the type of string enums in generated ApiProperty decorators
- 🐛 Do not set a class type in the ApiProperty decorator when NestJS can infer it
- 📝 Update changelog