### PR TITLE
🔖 Prepare v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.8.2 (2024-02-21)
+
 Fixes:
 
 - Disable pino logs when generating the OpenAPI specification. This prevents (non-error) logs from interfering with the outputted OpenAPI document.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.12.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": "github:causa-io/workspace-module-typescript",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Disable pino logs when generating the OpenAPI specification. This prevents (non-error) logs from interfering with the outputted OpenAPI document.

### Commits

- **📝 Update changelog**
- **🔖 Set version to 0.8.2**