### PR TITLE
🔖 Prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0 (2024-05-21)
+
 Breaking change:
 
 - Drop support for Node.js 16.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.13.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": "github:causa-io/workspace-module-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking change:

- Drop support for Node.js 16.

Chore:

- Upgrade dependencies.

Fixes:

- Always set the `required` attribute in the generated `ApiProperty` decorator.
- Use a file instead of the standard output to emit the OpenAPI specification. This prevents errors when the service produces logs.

### Commits

- **🔖 Set version to 0.9.0**
- **📝 Update changelog**