### PR TITLE
🔖 Prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.10.0 (2024-11-18)
+
 Breaking changes:
 
 - Use `@nestjs/swagger` `selfRequired` property when generating OpenAPI decorators. This property is only available with `@nestjs/swagger` version 8.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.16.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": "github:causa-io/workspace-module-typescript",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Use `@nestjs/swagger` `selfRequired` property when generating OpenAPI decorators. This property is only available with `@nestjs/swagger` version 8.

### Commits

- **🔖 Set version to 0.10.0**
- **📝 Update changelog**