### PR TITLE
🔖 Prepare v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.10.2 (2025-05-12)
+
 Chores:
 
 - Adapt to `quicktype` breaking changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.16.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": "github:causa-io/workspace-module-typescript",
   "license": "ISC",


### PR DESCRIPTION
Chores:

- Adapt to `quicktype` breaking changes.

### Commits

- **🔖 Set version to 0.10.2**
- **📝 Update changelog**