### PR TITLE
✨ Generate the `@Equals(null)` decorator for properties that are always `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes:
 
 - Upgrade the minimum Node.js version to `20`.
 
+Features:
+
+- Decorate `null` properties with `@Equals(null)` during code generation.
+
 ## v0.10.2 (2025-05-12)
 
 Chores:

--- a/src/code-generation/renderers/class-validator-transformer-renderer.spec.ts
+++ b/src/code-generation/renderers/class-validator-transformer-renderer.spec.ts
@@ -44,6 +44,7 @@ describe('ClassValidatorTransformerPropertyDecoratorsRenderer', () => {
         },
         myOverride: { type: 'integer', causa: { tsType: 'bigint' } },
         myObject: { type: 'object', additionalProperties: true },
+        myNull: { type: 'null' },
       },
       required: ['myClass'],
       additionalProperties: false,
@@ -70,5 +71,6 @@ describe('ClassValidatorTransformerPropertyDecoratorsRenderer', () => {
     );
     expect(actualCode).toMatch(/[^@]*\n\s+readonly myOverride/);
     expect(actualCode).toMatch(/@IsObject\(\)\n\s+readonly myObject/);
+    expect(actualCode).toMatch(/@Equals\(null\)\n\s+readonly myNull/);
   });
 });

--- a/src/code-generation/renderers/class-validator-transformer-renderer.ts
+++ b/src/code-generation/renderers/class-validator-transformer-renderer.ts
@@ -91,7 +91,18 @@ export class ClassValidatorTransformerPropertyDecoratorsRenderer extends TypeScr
     }
 
     const propertyType = removeNullFromType(context.property.type)[1];
-    if (propertyType.size !== 1) {
+    if (propertyType.size < 1) {
+      const decorators: TypeScriptDecorator[] = [];
+      this.addDecoratorToList(
+        decorators,
+        context,
+        'Equals',
+        CLASS_VALIDATOR_MODULE,
+        '@Equals(null)',
+      );
+      return decorators;
+    }
+    if (propertyType.size > 1) {
       return [];
     }
 


### PR DESCRIPTION
### 📝 Description of the PR

The title says it all. This improves the `ClassValidatorTransformerPropertyDecoratorsRenderer`.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.