### PR TITLE
✨ `constraintFor` support in code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Features:
 - Sort imports during code generation.
 - Generate `const` JSONSchema properties as constants rather than enums.
 - Implement the `typescriptModelClass` code generator.
+- Support `constraintFor` in code generation.
 
 ## v0.10.2 (2025-05-12)
 


### PR DESCRIPTION
### 📝 Description of the PR

This implements the support for the `constraintFor` Causa attribute in JSONSchema model definitions. In TypeScript, this generates a regular class for the object schema, but also generates a `type` that intersects with the "constrained base type" referenced by `constraintFor`.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.