### PR TITLE
✨ Default value override for test object code generator

### DIFF
--- a/src/code-generation/test-expectation/renderer.ts
+++ b/src/code-generation/test-expectation/renderer.ts
@@ -195,7 +195,7 @@ export class TypeScriptTestExpectationRenderer extends TypeScriptWithDecoratorsR
   ): void {
     this.emitPropertiesWithHandler(
       context,
-      (jsonName, { type, isOptional }, isConst) =>
+      ({ jsonName, property: { type, isOptional }, isConst }) =>
         filter(jsonName)
           ? this.getMatcherForType(type, { isOptional, isConst })
           : null,

--- a/src/code-generation/test-object/language.spec.ts
+++ b/src/code-generation/test-object/language.spec.ts
@@ -31,6 +31,10 @@ const SCHEMA = {
     },
     optionalString: { type: 'string' },
     optionalInteger: { type: 'integer' },
+    defaultStringProp: {
+      type: 'string',
+      causa: { testObjectDefaultValue: 'something' },
+    },
   },
   required: ['stringProp', 'integerProp', 'boolProp', 'arrayProp', 'classProp'],
   $defs: {
@@ -98,6 +102,7 @@ describe('TypeScriptTestObjectRenderer', () => {
       'constProp: "🪨",',
       'dateProp: new Date\\(\\),',
       'dateTimeProp: new Date\\(\\),',
+      'defaultStringProp: "something",',
       'doubleProp: 0\\.0,',
       'enumProp: MySpecialEnum.First,',
       'integerProp: 0,',
@@ -137,7 +142,7 @@ describe('TypeScriptTestObjectRenderer', () => {
       type: 'object',
       additionalProperties: false,
       properties: {
-        name: { type: 'string' },
+        name: { type: 'string', causa: { testObjectDefaultValue: 'name' } },
         age: { oneOf: [{ type: 'integer' }, { type: 'null' }] },
         dummyRefToConstraint: {
           oneOf: [{ $ref: '#/$defs/PersonWithAgeConstraint' }],
@@ -185,13 +190,13 @@ describe('TypeScriptTestObjectRenderer', () => {
       '\\): PersonWithAge \\{',
       'return new Person\\(\\{',
       'age: 0,',
-      'name: "string",',
+      'name: "name",',
       '...data,',
       '\\}\\) as PersonWithAge;',
       'export function makePerson\\(data: Partial<Person> = \\{\\}\\): Person \\{',
       'return new Person\\(\\{',
       'age: null,',
-      'name: "string",',
+      'name: "name",',
       '...data,',
       '\\}\\);',
     ]);


### PR DESCRIPTION
### 📝 Description of the PR

This adds support for the `testObjectDefaultValue` Causa attribute, overriding the type-inferred default value in test object utility functions.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.