### PR TITLE
🔖 Prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.0 (2025-08-28)
+
 Breaking changes:
 
 - Remove support for building serverless functions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.18.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Remove support for building serverless functions.
- Rename `ProjectBuildArtefactForTypeScriptPackage` to `ProjectBuildArtefactForJavaScriptPackage`, which now supports building JavaScript packages, and uses `npm pack` to produce an archive as artefact.
- Update `ProjectPushArtefactForNpmPackage` to publish from packed archives instead of directories.

Features:

- Add `javascript.npm.packDestination` configuration to specify npm pack output location.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- [x] 📝 Documentation has been updated.