### PR TITLE
🔖 Prepare v0.23.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.23.0-beta.1 (2026-05-18)
+
 Chores:
 
 - Adapt to `@causa/workspace` breaking changes: `_call` and `_supports` (and secondary helper methods) no longer receive a `context` argument and rely on the `_context` property instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.22.0",
+  "version": "0.23.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.22.0",
+      "version": "0.23.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.25.0-beta.3 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.22.0",
+  "version": "0.23.0-beta.1",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Chores:

- Adapt to `@causa/workspace` breaking changes: `_call` and `_supports` (and secondary helper methods) no longer receive a `context` argument and rely on the `_context` property instead.
- Replace `js-yaml` with `yaml`.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~