### PR TITLE
🔖 Prepare v0.23.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.23.0-beta.2 (2026-05-21)
+
 Breaking changes:
 
 - Rewrite the model class, test object, test expectation, and NestJS controller code generators to use the new `@causa/workspace-core` `Schema` model instead of `quicktype`. The `quicktype-core` dependency is removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.23.0-beta.1",
+  "version": "0.23.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.23.0-beta.1",
+      "version": "0.23.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.25.0-beta.3 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.23.0-beta.1",
+  "version": "0.23.0-beta.2",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Breaking changes:

- Rewrite the model class, test object, test expectation, and NestJS controller code generators to use the new `@causa/workspace-core` `Schema` model instead of `quicktype`. The `quicktype-core` dependency is removed.
- Replace `TypeScriptGetDecoratorRenderer` with the `ModelGenerateTypeScriptDecorators` workspace function, which is dispatched per object schema and property by the model class generator.
- Move the `constraintSuffix` option from each code generator's configuration to `model.constraintSuffix`, applying it consistently to every TypeScript model generator.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~