### PR TITLE
🐛 Fix code-generation naming and support union event data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+Features:
+
+- Support a `oneOf` of constraint refs as the `data` property of an entity mutated event. The generated expectation emits one matcher per variant inside `expect.toBeOneOf([...])`.
+
+Fixes:
+
+- Deduplicate PascalCased schema names so colliding identifiers (e.g. two schemas resolving to the same class name) no longer produce invalid TypeScript output. Names assigned to schemas are also passed to decorator providers, so decorators referencing class names (e.g. `@Type(() => Foo)`) use the final identifier.
+- Sort decorators by source before emitting them, ensuring stable output regardless of provider registration order.
+
 ## v0.23.0-beta.2 (2026-05-21)
 
 Breaking changes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.25.0-beta.3 < 1.0.0",
-        "@causa/workspace-core": ">= 0.35.0-beta.3 < 1.0.0",
+        "@causa/workspace-core": ">= 0.35.0-beta.4 < 1.0.0",
         "archiver": "^7.0.1",
         "audit-ci": "^7.1.0",
         "change-case": "^5.4.4",
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@causa/workspace-core": {
-      "version": "0.35.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@causa/workspace-core/-/workspace-core-0.35.0-beta.3.tgz",
-      "integrity": "sha512-Bgtzh/bO2ss6BXI1YUeDrJYJGNqjGP5gFjGMi0lnb14iUJyaJ6a2QtPiN2N/wXo6p+tlKrZdyTt5c5SUY9ZrVg==",
+      "version": "0.35.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@causa/workspace-core/-/workspace-core-0.35.0-beta.4.tgz",
+      "integrity": "sha512-m/dfsJuqlm5cLdTuCJOf7Zl9clxSxtkF6nRxLXJxkUSOKt8TKJYo7ZqwbTVTehVyZgJULNWGvwJkbhwyMYcgDA==",
       "license": "ISC",
       "dependencies": {
         "@causa/cli": ">= 0.8.0-beta.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@causa/workspace": ">= 0.25.0-beta.3 < 1.0.0",
-    "@causa/workspace-core": ">= 0.35.0-beta.3 < 1.0.0",
+    "@causa/workspace-core": ">= 0.35.0-beta.4 < 1.0.0",
     "archiver": "^7.0.1",
     "audit-ci": "^7.1.0",
     "change-case": "^5.4.4",

--- a/src/code-generation/base.spec.ts
+++ b/src/code-generation/base.spec.ts
@@ -1,0 +1,154 @@
+import type { Schema } from '@causa/workspace-core';
+import { assignSchemaNames } from './base.js';
+
+describe('assignSchemaNames', () => {
+  it('should deduplicate colliding PascalCase names and constraint aliases stably across path orderings', () => {
+    // Two distinct paths whose names PascalCase to the same identifier ("Thing").
+    const PATH_A = '/folder1/identical.yaml';
+    const PATH_B = '/folder2/identical.yaml';
+    // Object whose name collides with a constraint alias ("Foo").
+    const FOO_PATH = '/foo.yaml';
+    const FOO_CONSTRAINT_PATH = '/foo-constraint.yaml';
+    // Triple collision after PascalCase.
+    const ENUM_C1 = '/c/one.yaml#/$defs/Status';
+    const ENUM_C2 = '/c/two.yaml#/$defs/Status';
+    const ENUM_C3 = '/c/three.yaml#/$defs/Status';
+    const schemas: Record<string, Schema> = {
+      [PATH_A]: {
+        kind: 'object',
+        name: 'thing',
+        path: PATH_A,
+        extensions: {},
+        databases: [],
+        properties: [],
+      },
+      [PATH_B]: {
+        kind: 'object',
+        name: 'Thing',
+        path: PATH_B,
+        extensions: {},
+        databases: [],
+        properties: [],
+      },
+      [FOO_PATH]: {
+        kind: 'object',
+        name: 'Foo',
+        path: FOO_PATH,
+        extensions: {},
+        databases: [],
+        properties: [],
+      },
+      [FOO_CONSTRAINT_PATH]: {
+        kind: 'object',
+        name: 'FooConstraint',
+        path: FOO_CONSTRAINT_PATH,
+        extensions: { constraintFor: FOO_PATH },
+        databases: [],
+        properties: [],
+      },
+      [ENUM_C1]: {
+        kind: 'enum',
+        type: 'string',
+        name: 'status',
+        path: ENUM_C1,
+        extensions: {},
+        values: ['a'],
+      },
+      [ENUM_C2]: {
+        kind: 'enum',
+        type: 'string',
+        name: 'Status',
+        path: ENUM_C2,
+        extensions: {},
+        values: ['b'],
+      },
+      [ENUM_C3]: {
+        kind: 'enum',
+        type: 'string',
+        name: 'STATUS',
+        path: ENUM_C3,
+        extensions: {},
+        values: ['c'],
+      },
+    };
+
+    const deduped = assignSchemaNames(schemas);
+
+    expect(deduped[ENUM_C1].name).toBe('Status');
+    expect(deduped[ENUM_C2].name).toBe('Status_3');
+    expect(deduped[ENUM_C3].name).toBe('Status_2');
+    expect(deduped[FOO_PATH].name).toBe('Foo_2');
+    expect(deduped[FOO_CONSTRAINT_PATH].name).toBe('FooConstraint');
+    expect(deduped[PATH_A].name).toBe('Thing');
+    expect(deduped[PATH_B].name).toBe('Thing_2');
+
+    // Stability: shuffling the input order yields the same result.
+    const shuffled: Record<string, Schema> = {
+      [PATH_B]: schemas[PATH_B],
+      [ENUM_C3]: schemas[ENUM_C3],
+      [FOO_CONSTRAINT_PATH]: schemas[FOO_CONSTRAINT_PATH],
+      [PATH_A]: schemas[PATH_A],
+      [ENUM_C2]: schemas[ENUM_C2],
+      [FOO_PATH]: schemas[FOO_PATH],
+      [ENUM_C1]: schemas[ENUM_C1],
+    };
+
+    const dedupedShuffled = assignSchemaNames(shuffled);
+
+    expect(dedupedShuffled).toEqual(deduped);
+  });
+
+  it('should deduplicate against existingSchemas names', () => {
+    const NEW_PATH = '/new.yaml';
+    const EXISTING_PATH = '/existing.yaml';
+    const schemas: Record<string, Schema> = {
+      [NEW_PATH]: {
+        kind: 'object',
+        name: 'Shared',
+        path: NEW_PATH,
+        extensions: {},
+        databases: [],
+        properties: [],
+      },
+    };
+
+    const deduped = assignSchemaNames(schemas, {
+      existingSchemas: {
+        [EXISTING_PATH]: { name: 'Shared', file: '/existing.ts' },
+      },
+    });
+
+    expect(deduped[NEW_PATH].name).toBe('Shared_2');
+  });
+
+  it('should strip the constraint suffix before PascalCasing so custom suffixes are preserved', () => {
+    // Schema named with the custom suffix verbatim; PascalCase-then-strip would mangle "_rule".
+    const SUFFIX_PATH = '/foo.yaml';
+    const SCHEMA_PATH = '/foo_rule.yaml';
+    const schemas: Record<string, Schema> = {
+      [SUFFIX_PATH]: {
+        kind: 'object',
+        name: 'foo',
+        path: SUFFIX_PATH,
+        extensions: {},
+        databases: [],
+        properties: [],
+      },
+      [SCHEMA_PATH]: {
+        kind: 'object',
+        name: 'foo_rule',
+        path: SCHEMA_PATH,
+        extensions: { constraintFor: SUFFIX_PATH },
+        databases: [],
+        properties: [],
+      },
+    };
+
+    const deduped = assignSchemaNames(schemas, {
+      constraintSuffix: '_rule',
+    });
+
+    expect(deduped[SUFFIX_PATH].name).toBe('Foo_2');
+    expect(deduped[SCHEMA_PATH].name).toBe('Foo_rule');
+  });
+});

--- a/src/code-generation/base.ts
+++ b/src/code-generation/base.ts
@@ -41,6 +41,88 @@ export function stripConstraintSuffix(name: string, suffix: string): string {
 }
 
 /**
+ * Returns a shallow copy of `schemas` with each schema's `name` rewritten to a PascalCase, deduplicated identifier
+ * suitable for use as a TypeScript top-level export. All emitted names (object classes, constraint aliases + their
+ * constraint classes, enums, unions) share a single global namespace. Collisions are resolved by appending `_2`,
+ * `_3`, … to the colliding name. For constraint schemas the stripped (alias) form is deduplicated first, then the
+ * suffix is reapplied to derive the class name, so both names land in the taken set.
+ *
+ * Schemas whose path appears in `options.existingSchemas` are rewritten to use the existing name verbatim and are
+ * also registered into the taken set, so newly-emitted names never clash with imported ones.
+ *
+ * Iteration is path-sorted, so the deduplication numbering is stable across runs regardless of the upstream scan order.
+ *
+ * @param schemas The schema map to normalize.
+ * @param options Normalization options.
+ * @returns A new schema map with the rewritten names. Schema instances are themselves cloned shallowly; nested
+ *   properties / types are shared with the input.
+ */
+export function assignSchemaNames(
+  schemas: Record<string, Schema>,
+  options: {
+    /**
+     * Suffix used to identify constraint classes.
+     * Defaults to {@link DEFAULT_CONSTRAINT_SUFFIX}.
+     */
+    constraintSuffix?: string;
+
+    /**
+     * Schemas already emitted by a previous generator run, keyed by absolute schema path.
+     */
+    existingSchemas?: GeneratedSchemas;
+  } = {},
+): Record<string, Schema> {
+  const constraintSuffix =
+    options.constraintSuffix ?? DEFAULT_CONSTRAINT_SUFFIX;
+  const existingSchemas = options.existingSchemas ?? {};
+  const taken = new Set<string>(
+    Object.values(existingSchemas).map((s) => s.name),
+  );
+
+  const dedupe = (candidate: string): string => {
+    if (!taken.has(candidate)) {
+      return candidate;
+    }
+
+    for (let i = 2; ; i++) {
+      const next = `${candidate}_${i}`;
+      if (!taken.has(next)) {
+        return next;
+      }
+    }
+  };
+
+  const result: Record<string, Schema> = {};
+  const paths = Object.keys(schemas).toSorted((a, b) => a.localeCompare(b));
+  for (const path of paths) {
+    const schema = schemas[path];
+    const existing = existingSchemas[path];
+    if (existing) {
+      result[path] = { ...schema, name: existing.name };
+      continue;
+    }
+
+    let name: string;
+    if (getConstraintBasePath(schema) !== undefined) {
+      const aliasCandidate = pascalCase(
+        stripConstraintSuffix(schema.name, constraintSuffix),
+      );
+      const alias = dedupe(aliasCandidate);
+      name = `${alias}${constraintSuffix}`;
+      taken.add(alias);
+      taken.add(name);
+    } else {
+      name = dedupe(pascalCase(schema.name));
+      taken.add(name);
+    }
+
+    result[path] = { ...schema, name };
+  }
+
+  return result;
+}
+
+/**
  * Returns the path of the schema constrained by `schema` (via `extensions.constraintFor`), or `undefined` when
  * `schema` is not an object schema or carries no `constraintFor` extension.
  */

--- a/src/code-generation/model-class/generator.ts
+++ b/src/code-generation/model-class/generator.ts
@@ -7,7 +7,6 @@ import type {
   Schema,
   UnionSchema,
 } from '@causa/workspace-core';
-import { pascalCase } from 'change-case';
 import {
   BaseTypeScriptCodeGenerator,
   collectRefs,
@@ -118,11 +117,12 @@ export class TypeScriptModelClassGenerator extends BaseTypeScriptCodeGenerator {
         continue;
       }
 
-      this.classNames[path] = pascalCase(schema.name);
+      this.classNames[path] = schema.name;
 
       if (getConstraintBasePath(schema) !== undefined) {
-        this.constraintAliasNames[path] = pascalCase(
-          stripConstraintSuffix(schema.name, this.constraintSuffix),
+        this.constraintAliasNames[path] = stripConstraintSuffix(
+          schema.name,
+          this.constraintSuffix,
         );
       }
     }

--- a/src/code-generation/model-class/generator.ts
+++ b/src/code-generation/model-class/generator.ts
@@ -278,7 +278,7 @@ export class TypeScriptModelClassGenerator extends BaseTypeScriptCodeGenerator {
     for (const decorator of [
       ...extClassDecorators,
       ...(schemaDecorators?.class ?? []),
-    ]) {
+    ].toSorted((a, b) => a.source.localeCompare(b.source))) {
       this.addImports(decorator.imports);
       lines.push(decorator.source);
     }
@@ -311,13 +311,11 @@ export class TypeScriptModelClassGenerator extends BaseTypeScriptCodeGenerator {
 
     const extDecorators = (property.extensions.tsDecorators ??
       []) as TypeScriptDecorator[];
-    for (const decorator of extDecorators) {
-      this.addImports(decorator.imports);
-      lines.push(decorator.source);
-    }
     const propertyDecorators =
       schemaDecorators?.properties[property.name] ?? [];
-    for (const decorator of propertyDecorators) {
+    for (const decorator of [...extDecorators, ...propertyDecorators].toSorted(
+      (a, b) => a.source.localeCompare(b.source),
+    )) {
       this.addImports(decorator.imports);
       lines.push(decorator.source);
     }

--- a/src/code-generation/test-expectation/generator.spec.ts
+++ b/src/code-generation/test-expectation/generator.spec.ts
@@ -1062,4 +1062,175 @@ describe('TypeScriptTestExpectationGenerator', () => {
       },
     });
   });
+
+  it('should generate a multi-variant entity mutated expectation when data is a union of constraints', async () => {
+    const ENTITY_PATH = `${schemaUri}#/$defs/Entity`;
+    const VARIANT_A_PATH = `${schemaUri}#/$defs/EntityVariantAConstraint`;
+    const VARIANT_B_PATH = `${schemaUri}#/$defs/EntityVariantBConstraint`;
+    const UNION_PATH = `${schemaUri}#/$defs/EntityVariantUnion`;
+    const MUTATION_PATH = `${schemaUri}#/$defs/EntityMutatedEventConstraint`;
+
+    const schemas: Record<string, Schema> = {
+      [schemaUri]: {
+        kind: 'object',
+        name: 'EntityEvent',
+        path: schemaUri,
+        extensions: {},
+        databases: [],
+        properties: [
+          {
+            name: 'name',
+            type: { kind: 'const', type: 'string', value: 'entityMutated' },
+            nullable: false,
+            required: true,
+            extensions: {},
+          },
+          {
+            name: 'data',
+            type: { kind: 'ref', ref: ENTITY_PATH },
+            nullable: false,
+            required: true,
+            extensions: {},
+          },
+        ],
+      },
+      [ENTITY_PATH]: {
+        kind: 'object',
+        name: 'Entity',
+        path: ENTITY_PATH,
+        extensions: {},
+        databases: [],
+        properties: [
+          {
+            name: 'id',
+            type: { kind: 'primitive', type: 'uuid' },
+            nullable: false,
+            required: true,
+            extensions: {},
+          },
+          {
+            name: 'state',
+            type: { kind: 'primitive', type: 'string' },
+            nullable: false,
+            required: true,
+            extensions: {},
+          },
+        ],
+      },
+      [VARIANT_A_PATH]: {
+        kind: 'object',
+        name: 'EntityVariantAConstraint',
+        path: VARIANT_A_PATH,
+        extensions: { constraintFor: ENTITY_PATH },
+        databases: [],
+        properties: [
+          {
+            name: 'state',
+            type: { kind: 'const', type: 'string', value: 'a' },
+            nullable: false,
+            required: true,
+            extensions: {},
+          },
+        ],
+      },
+      [VARIANT_B_PATH]: {
+        kind: 'object',
+        name: 'EntityVariantBConstraint',
+        path: VARIANT_B_PATH,
+        extensions: { constraintFor: ENTITY_PATH },
+        databases: [],
+        properties: [
+          {
+            name: 'state',
+            type: { kind: 'const', type: 'string', value: 'b' },
+            nullable: false,
+            required: true,
+            extensions: {},
+          },
+        ],
+      },
+      [UNION_PATH]: {
+        kind: 'union',
+        name: 'EntityVariantUnion',
+        path: UNION_PATH,
+        extensions: {},
+        types: [
+          { kind: 'ref', ref: VARIANT_A_PATH },
+          { kind: 'ref', ref: VARIANT_B_PATH },
+        ],
+      },
+      [MUTATION_PATH]: {
+        kind: 'object',
+        name: 'EntityMutatedEventConstraint',
+        path: MUTATION_PATH,
+        extensions: {
+          constraintFor: schemaUri,
+          entityMutationFrom: [ENTITY_PATH],
+          entityPropertyChanges: ['state'],
+        },
+        databases: [],
+        properties: [
+          {
+            name: 'data',
+            type: { kind: 'ref', ref: UNION_PATH },
+            nullable: false,
+            required: true,
+            extensions: {},
+          },
+        ],
+      },
+    };
+    const modelClassSchemas: GeneratedSchemas = {
+      [schemaUri]: {
+        file: join(tmpDir, 'models/event.ts'),
+        name: 'EntityEvent',
+      },
+      [ENTITY_PATH]: { file: join(tmpDir, 'models/event.ts'), name: 'Entity' },
+      [VARIANT_A_PATH]: {
+        file: join(tmpDir, 'models/event.ts'),
+        name: 'EntityVariantA',
+      },
+      [VARIANT_B_PATH]: {
+        file: join(tmpDir, 'models/event.ts'),
+        name: 'EntityVariantB',
+      },
+      [UNION_PATH]: {
+        file: join(tmpDir, 'models/event.ts'),
+        name: 'EntityVariantUnion',
+      },
+      [MUTATION_PATH]: {
+        file: join(tmpDir, 'models/event.ts'),
+        name: 'EntityMutatedEvent',
+      },
+    };
+    const eventTopics: EventTopicDefinition[] = [
+      { id: 'entity-events', schemaFilePath: schemaUri, formatParts: {} },
+    ];
+
+    const { source } = await generate(
+      schemas,
+      modelClassSchemas,
+      eventTopics,
+      {},
+    );
+
+    expectToMatchRegexParts(source, [
+      'export async function expectEntityMutatedEvent\\(',
+      'fixture: AppFixture,',
+      'before: Partial<Entity>,',
+      'updates: Partial<EntityVariantA \\| EntityVariantB> = \\{\\},',
+      'expectedEntity: expect\\.toBeOneOf\\(\\[',
+      // First variant block.
+      'id: expect\\.any\\(String\\),',
+      '\\.\\.\\.before,',
+      'state: "a",',
+      '\\.\\.\\.updates,',
+      // Second variant block.
+      'id: expect\\.any\\(String\\),',
+      '\\.\\.\\.before,',
+      'state: "b",',
+      '\\.\\.\\.updates,',
+      '\\]\\),',
+    ]);
+  });
 });

--- a/src/code-generation/test-expectation/generator.ts
+++ b/src/code-generation/test-expectation/generator.ts
@@ -246,7 +246,7 @@ export class TypeScriptTestExpectationGenerator extends BaseTypeScriptCodeGenera
     eventTopic: EventTopicDefinition,
     blocks: string[],
   ): string[] {
-    const dataObject = this.eventDataObject(schema);
+    const [dataObject] = this.eventDataObjects(schema);
     const entityClass = findModelClass(this.modelClassSchemas, dataObject.path);
     this.addImports({ [entityClass.file]: [entityClass.name] });
     this.addImports({
@@ -295,28 +295,24 @@ export class TypeScriptTestExpectationGenerator extends BaseTypeScriptCodeGenera
       );
     }
 
-    const entityObject = this.eventDataObject(baseEvent);
-    const constrainedEntityObject = this.eventDataObject(schema, baseEvent);
-
+    const [entityObject] = this.eventDataObjects(baseEvent);
     const entityClass = findModelClass(
       this.modelClassSchemas,
       entityObject.path,
     );
-    const constrainedEntityClass = findModelClass(
-      this.modelClassSchemas,
-      constrainedEntityObject.path,
-    );
-    const isConstrainedEntity =
-      getConstraintBasePath(constrainedEntityObject) !== undefined;
-
-    this.addImports({
-      [constrainedEntityClass.file]: [
-        isConstrainedEntity
-          ? `type ${constrainedEntityClass.name}`
-          : constrainedEntityClass.name,
-      ],
-    });
     this.addImports({ [entityClass.file]: [entityClass.name] });
+
+    const variants = this.eventDataObjects(schema, baseEvent);
+    const variantClasses = variants.map((v) => {
+      const isConstraint = getConstraintBasePath(v) !== undefined;
+      const variantClass = findModelClass(this.modelClassSchemas, v.path);
+      this.addImports({
+        [variantClass.file]: [
+          isConstraint ? `type ${variantClass.name}` : variantClass.name,
+        ],
+      });
+      return variantClass;
+    });
 
     const eventNameProperty =
       schema.properties.find((p) => p.name === 'name') ??
@@ -351,14 +347,14 @@ export class TypeScriptTestExpectationGenerator extends BaseTypeScriptCodeGenera
     const functionName = `expect${this.functionBaseName(schema)}`;
     const eventNameMatcher = `expect.toBeOneOf(${JSON.stringify(eventNames)})`;
     const entityMatchers = this.emitExpectedEntityMatchers(
-      constrainedEntityObject,
+      variants,
       schema.extensions.entityPropertyChanges as string[] | '*' | undefined,
     );
 
     blocks.push(`export async function ${functionName}(
   fixture: AppFixture,
   before: Partial<${entityClass.name}>,
-  updates: Partial<${constrainedEntityClass.name}> = {},
+  updates: Partial<${variantClasses.map((c) => c.name).join(' | ')}> = {},
   tests: {
     matchesHttpResponse?: object;
     eventAttributes?: EventAttributes;
@@ -367,9 +363,7 @@ export class TypeScriptTestExpectationGenerator extends BaseTypeScriptCodeGenera
   return await fixture.get(VersionedEntityFixture).expectMutated(
     { type: ${entityClass.name}, entity: before },
     {
-      expectedEntity: {
-        ${entityMatchers}
-      },
+      expectedEntity: ${entityMatchers},
       expectedEvent: {
         topic: ${JSON.stringify(eventTopic.id)},
         name: ${eventNameMatcher},
@@ -384,49 +378,82 @@ export class TypeScriptTestExpectationGenerator extends BaseTypeScriptCodeGenera
   }
 
   /**
-   * Returns the source for the `expectedEntity` block of an entity mutation expectation, interleaving `before` and
-   * `updates` spreads with the property matchers as dictated by `entityPropertyChanges`.
+   * Returns the source for the `expectedEntity` value of an entity mutation expectation. For a single variant the
+   * returned source is a `{ ... }` object literal interleaving `before` and `updates` spreads with the property
+   * matchers as dictated by `entityPropertyChanges`. For multiple variants (when the `data` property is a `oneOf` of
+   * constraint refs) the source is an `expect.toBeOneOf([ { ... }, ... ])` matcher, one object per variant.
    */
   private emitExpectedEntityMatchers(
-    entityObject: ObjectSchema,
+    variants: ObjectSchema[],
     changes: string[] | '*' | undefined,
   ): string {
-    if (changes === '*') {
-      return `${this.emitPropertyMatchers(entityObject)}\n...updates,`;
+    const buildBody = (variant: ObjectSchema): string => {
+      if (changes === '*') {
+        return `{ ${this.emitPropertyMatchers(variant)}\n...updates }`;
+      }
+
+      const set = new Set(changes ?? []);
+      return `{
+${this.emitPropertyMatchers(variant, (n) => !set.has(n))}
+...before,
+${this.emitPropertyMatchers(variant, (n) => set.has(n))}
+...updates
+}`;
+    };
+
+    if (variants.length === 1) {
+      return buildBody(variants[0]);
     }
 
-    const set = new Set(changes ?? []);
-    return `${this.emitPropertyMatchers(entityObject, (n) => !set.has(n))}
-...before,
-${this.emitPropertyMatchers(entityObject, (n) => set.has(n))}
-...updates,`;
+    return `expect.toBeOneOf([
+      ${variants.map((v) => buildBody(v)).join(',\n')}
+    ])`;
   }
 
   /**
-   * Returns the object schema reached by the `data` property of the given event object schema, falling back to the
-   * `baseSchema`'s `data` property when the constraint omits it.
+   * Returns the object schemas reached by the `data` property of the given event object schema, falling back to the
+   * `baseSchema`'s `data` property when the constraint omits it. Always returns at least one variant. When the `data`
+   * property is a single ref the array has one element; when it is a union (directly or by reference) every member
+   * must resolve to an object schema and is included in the returned array.
    */
-  private eventDataObject(
+  private eventDataObjects(
     schema: ObjectSchema,
     baseSchema?: ObjectSchema,
-  ): ObjectSchema {
+  ): ObjectSchema[] {
     const dataProperty =
       schema.properties.find((p) => p.name === 'data') ??
       baseSchema?.properties.find((p) => p.name === 'data');
-    if (dataProperty?.type.kind !== 'ref') {
+    if (!dataProperty) {
       throw new Error(
         `Entity event '${schema.name}' must have a 'data' object property.`,
       );
     }
 
-    const target = this.schemas[dataProperty.type.ref];
-    if (target?.kind !== 'object') {
+    if (dataProperty.type.kind !== 'ref') {
       throw new Error(
-        `Entity event '${schema.name}' 'data' property must reference an object schema.`,
+        `Entity event '${schema.name}' must have a 'data' object property.`,
       );
     }
+    const refTarget = this.schemas[dataProperty.type.ref];
+    const memberTypes: PropertyType[] =
+      refTarget?.kind === 'union' ? refTarget.types : [dataProperty.type];
 
-    return target;
+    const variants: ObjectSchema[] = [];
+    for (const member of memberTypes) {
+      if (member.kind !== 'ref') {
+        throw new Error(
+          `Entity event '${schema.name}' 'data' property must reference an object schema.`,
+        );
+      }
+      const target = this.schemas[member.ref];
+      if (target?.kind !== 'object') {
+        throw new Error(
+          `Entity event '${schema.name}' 'data' property must reference an object schema.`,
+        );
+      }
+      variants.push(target);
+    }
+    return variants;
   }
 
   /**

--- a/src/code-generation/test-expectation/generator.ts
+++ b/src/code-generation/test-expectation/generator.ts
@@ -12,7 +12,6 @@ import type {
 import micromatch from 'micromatch';
 import {
   BaseTypeScriptCodeGenerator,
-  DEFAULT_CONSTRAINT_SUFFIX,
   enumCaseNames,
   findEnumCaseName,
   findModelClass,
@@ -20,14 +19,13 @@ import {
   getConstraintBasePath,
   propertyKey,
   resolveEnumForObjectProperty,
-  stripConstraintSuffix,
 } from '../base.js';
 
 /**
  * Options for {@link TypeScriptTestExpectationGenerator}.
  */
 export type TypeScriptTestExpectationGeneratorOptions = Partial<
-  Pick<TypeScriptTestExpectationGenerator, 'constraintSuffix' | 'entitiesGlobs'>
+  Pick<TypeScriptTestExpectationGenerator, 'entitiesGlobs'>
 >;
 
 /**
@@ -43,11 +41,6 @@ export type TypeScriptTestExpectationGeneratorOptions = Partial<
  *    schemas) `expect<EntityName>NotToExist`.
  */
 export class TypeScriptTestExpectationGenerator extends BaseTypeScriptCodeGenerator {
-  /**
-   * The suffix used to identify constraint classes. Defaults to `Constraint`.
-   */
-  readonly constraintSuffix: string;
-
   /**
    * Absolute globs describing which schemas should generate entity expectations. When omitted, every schema not
    * matching a more specific case generates entity expectations.
@@ -73,8 +66,6 @@ export class TypeScriptTestExpectationGenerator extends BaseTypeScriptCodeGenera
     readonly options: TypeScriptTestExpectationGeneratorOptions = {},
   ) {
     super(outputPath);
-    this.constraintSuffix =
-      options.constraintSuffix ?? DEFAULT_CONSTRAINT_SUFFIX;
     this.entitiesGlobs = options.entitiesGlobs;
   }
 
@@ -580,12 +571,11 @@ ${this.emitPropertyMatchers(entityObject, (n) => set.has(n))}
   }
 
   /**
-   * Returns the PascalCase base name used to build expectation function names (e.g. `expect<X>`). Constraint
-   * schemas have their suffix stripped so a `FooConstraint` becomes `expectFoo`.
+   * Returns the base name used to build expectation function names (e.g. `expect<X>`). Mirrors the corresponding
+   * model-class output name, so a `FooConstraint` schema (whose model-class output is the alias `Foo`) becomes
+   * `expectFoo`.
    */
   private functionBaseName(schema: ObjectSchema): string {
-    return getConstraintBasePath(schema) !== undefined
-      ? stripConstraintSuffix(schema.name, this.constraintSuffix)
-      : schema.name;
+    return findModelClass(this.modelClassSchemas, schema.path).name;
   }
 }

--- a/src/code-generation/test-object/generator.spec.ts
+++ b/src/code-generation/test-object/generator.spec.ts
@@ -270,7 +270,7 @@ describe('TypeScriptTestObjectGenerator', () => {
       'arrayOfEnums: \\[MySpecialEnum.Second, MySpecialEnum.Third\\],',
       'arrayProp: \\[\\],',
       'boolProp: false,',
-      'classProp: makeChildClass\\(\\),',
+      'classProp: makeOtherName\\(\\),',
       'constProp: "🪨",',
       'dateProp: new Date\\(\\),',
       'dateTimeProp: new Date\\(\\),',
@@ -291,7 +291,7 @@ describe('TypeScriptTestObjectGenerator', () => {
       '}\\);',
     ]);
     expectToMatchRegexParts(source, [
-      'export function makeChildClass\\(data: Partial<OtherName> = {}\\): OtherName \\{',
+      'export function makeOtherName\\(data: Partial<OtherName> = {}\\): OtherName \\{',
       'return new OtherName\\({',
       'childNumber: 0,',
       'childString: "string",',
@@ -303,7 +303,7 @@ describe('TypeScriptTestObjectGenerator', () => {
     expect(source).not.toContain('🙈');
     expect(generatedSchemas).toEqual({
       [TEST_PATH]: { name: 'makeTestClass', file: outputFile },
-      [CHILD_PATH]: { name: 'makeChildClass', file: outputFile },
+      [CHILD_PATH]: { name: 'makeOtherName', file: outputFile },
     });
   });
 

--- a/src/code-generation/test-object/generator.ts
+++ b/src/code-generation/test-object/generator.ts
@@ -10,22 +10,13 @@ import type {
 import {
   BaseTypeScriptCodeGenerator,
   collectRefs,
-  DEFAULT_CONSTRAINT_SUFFIX,
   findEnumCaseName,
   findModelClass,
   getConstraintBaseObject,
   getConstraintBasePath,
   propertyKey,
-  stripConstraintSuffix,
   topologicalSort,
 } from '../base.js';
-
-/**
- * Options for {@link TypeScriptTestObjectGenerator}.
- */
-export type TypeScriptTestObjectGeneratorOptions = Partial<
-  Pick<TypeScriptTestObjectGenerator, 'constraintSuffix'>
->;
 
 /**
  * Generates TypeScript `make*` factory functions for the given {@link Schema}s and writes the formatted output to
@@ -38,11 +29,6 @@ export type TypeScriptTestObjectGeneratorOptions = Partial<
  */
 export class TypeScriptTestObjectGenerator extends BaseTypeScriptCodeGenerator {
   /**
-   * The suffix used to identify constraint classes. Defaults to `Constraint`.
-   */
-  readonly constraintSuffix: string;
-
-  /**
    * Creates a new generator.
    *
    * @param outputPath Absolute path of the file the rendered source will be written to.
@@ -51,17 +37,13 @@ export class TypeScriptTestObjectGenerator extends BaseTypeScriptCodeGenerator {
    *   default-value emitter introspects them.
    * @param modelClassSchemas The output of the model-class generator, used to look up the class / enum name and the
    *   file each model-class symbol lives in.
-   * @param options Options.
    */
   constructor(
     outputPath: string,
     readonly schemas: Record<string, Schema>,
     readonly modelClassSchemas: GeneratedSchemas,
-    readonly options: TypeScriptTestObjectGeneratorOptions = {},
   ) {
     super(outputPath);
-    this.constraintSuffix =
-      options.constraintSuffix ?? DEFAULT_CONSTRAINT_SUFFIX;
   }
 
   /**
@@ -107,7 +89,7 @@ export class TypeScriptTestObjectGenerator extends BaseTypeScriptCodeGenerator {
     const constraintForPath = getConstraintBasePath(schema);
     const isConstraint = constraintForPath !== undefined;
     const modelClass = findModelClass(this.modelClassSchemas, schema.path);
-    const functionName = `make${this.factoryNameFor(schema)}`;
+    const functionName = `make${modelClass.name}`;
 
     let instantiationClassName: string;
     if (constraintForPath !== undefined) {
@@ -255,7 +237,7 @@ export class TypeScriptTestObjectGenerator extends BaseTypeScriptCodeGenerator {
           return `${modelClass.name}.${caseName}`;
         }
         if (target?.kind === 'object') {
-          return `make${this.factoryNameFor(target)}(${serialized ?? ''})`;
+          return `make${findModelClass(this.modelClassSchemas, target.path).name}(${serialized ?? ''})`;
         }
         if (target?.kind === 'union') {
           const firstType = target.types[0];
@@ -304,15 +286,5 @@ export class TypeScriptTestObjectGenerator extends BaseTypeScriptCodeGenerator {
         return 'randomUUID()';
       }
     }
-  }
-
-  /**
-   * Returns the PascalCase factory base name for the given object schema. Constraint schemas have their suffix
-   * stripped so a `FooConstraint` schema becomes `makeFoo`.
-   */
-  private factoryNameFor(schema: ObjectSchema): string {
-    return getConstraintBasePath(schema) !== undefined
-      ? stripConstraintSuffix(schema.name, this.constraintSuffix)
-      : schema.name;
   }
 }

--- a/src/functions/model/run-code-generator-model-class.ts
+++ b/src/functions/model/run-code-generator-model-class.ts
@@ -3,6 +3,7 @@ import {
   type GeneratedSchemas,
   type Schema,
 } from '@causa/workspace-core';
+import { assignSchemaNames } from '../../code-generation/base.js';
 import {
   TypeScriptModelClassGenerator,
   type ModelClassSchemaDecorators,
@@ -32,7 +33,11 @@ export class ModelRunCodeGeneratorForTypeScriptModelClass extends ModelRunCodeGe
       .asConfiguration<TypeScriptModelConfiguration>()
       .get('model.constraintSuffix');
 
-    const schemas = await parseInputSchemas(this._context, this.configuration);
+    const inputSchemas = await parseInputSchemas(
+      this._context,
+      this.configuration,
+    );
+    const schemas = assignSchemaNames(inputSchemas, { constraintSuffix });
     const decorators = await this.computeTypeScriptDecorators(schemas);
 
     const codeGenerator = new TypeScriptModelClassGenerator(

--- a/src/functions/model/run-code-generator-nestjs-controller.ts
+++ b/src/functions/model/run-code-generator-nestjs-controller.ts
@@ -8,6 +8,7 @@ import {
 import { loadSchemas } from '@causa/workspace-core/jsonschema';
 import { mkdir, readFile } from 'fs/promises';
 import { basename, join } from 'path';
+import { assignSchemaNames } from '../../code-generation/base.js';
 import {
   makeParametersSchemasForSpecification,
   parseOpenApiSpec,
@@ -135,24 +136,28 @@ export class ModelRunCodeGeneratorForTypeScriptNestjsController extends ModelRun
    * the {@link GeneratedSchemas} the controller renderer relies on. Decorator computation is skipped for paths in
    * `existingSchemas` since those classes are imported, not emitted.
    *
-   * @param schemas The parameter schemas plus any external schemas reachable from their `$ref`s.
+   * @param rawSchemas The parameter schemas plus any external schemas reachable from their `$ref`s.
    * @param modelFilePath The file path to generate the classes at.
    * @param existingSchemas Schemas already emitted by a previous generator that should be imported instead of
    *   re-emitted. Passed straight to {@link TypeScriptModelClassGenerator}.
    * @returns The generated schemas, keyed by the synthetic parameter schema paths.
    */
   private async generateParameterSchemas(
-    schemas: Record<string, Schema>,
+    rawSchemas: Record<string, Schema>,
     modelFilePath: string,
     existingSchemas: GeneratedSchemas,
   ): Promise<GeneratedSchemas> {
-    if (Object.keys(schemas).length === 0) {
+    if (Object.keys(rawSchemas).length === 0) {
       return {};
     }
 
     const constraintSuffix = this._context
       .asConfiguration<TypeScriptModelConfiguration>()
       .get('model.constraintSuffix');
+    const schemas = assignSchemaNames(rawSchemas, {
+      constraintSuffix,
+      existingSchemas,
+    });
 
     const decorators: Record<string, ModelClassSchemaDecorators> = {};
     for (const schema of Object.values(schemas)) {

--- a/src/functions/model/run-code-generator-test-expectation.ts
+++ b/src/functions/model/run-code-generator-test-expectation.ts
@@ -5,7 +5,6 @@ import {
 } from '@causa/workspace-core';
 import { resolve } from 'path';
 import { TypeScriptTestExpectationGenerator } from '../../code-generation/index.js';
-import type { TypeScriptModelConfiguration } from '../../configurations/index.js';
 import { TYPESCRIPT_MODEL_CLASS_GENERATOR } from './run-code-generator-model-class.js';
 import {
   parseInputSchemas,
@@ -53,16 +52,13 @@ export class ModelRunCodeGeneratorForTypeScriptTestExpectation extends ModelRunC
     const entitiesGlobs = this.configuration.entitiesGlobs?.map((g) =>
       resolve(projectPath, g),
     );
-    const constraintSuffix = this._context
-      .asConfiguration<TypeScriptModelConfiguration>()
-      .get('model.constraintSuffix');
 
     const generator = new TypeScriptTestExpectationGenerator(
       outputPath,
       schemas,
       modelClassSchemas,
       eventTopics,
-      { entitiesGlobs, constraintSuffix },
+      { entitiesGlobs },
     );
     await generator.generate();
 

--- a/src/functions/model/run-code-generator-test-object.ts
+++ b/src/functions/model/run-code-generator-test-object.ts
@@ -3,7 +3,6 @@ import {
   type GeneratedSchemas,
 } from '@causa/workspace-core';
 import { TypeScriptTestObjectGenerator } from '../../code-generation/index.js';
-import type { TypeScriptModelConfiguration } from '../../configurations/index.js';
 import { TYPESCRIPT_MODEL_CLASS_GENERATOR } from './run-code-generator-model-class.js';
 import {
   parseInputSchemas,
@@ -33,15 +32,11 @@ export class ModelRunCodeGeneratorForTypeScriptTestObject extends ModelRunCodeGe
       TYPESCRIPT_MODEL_CLASS_GENERATOR,
     );
     const schemas = await parseInputSchemas(this._context, this.configuration);
-    const constraintSuffix = this._context
-      .asConfiguration<TypeScriptModelConfiguration>()
-      .get('model.constraintSuffix');
 
     const generator = new TypeScriptTestObjectGenerator(
       outputPath,
       schemas,
       modelClassSchemas,
-      { constraintSuffix },
     );
     await generator.generate();
 


### PR DESCRIPTION
### 📝 Description of the PR

Two follow-ups to the code-generation rewrite landed in v0.23.0-beta.2, plus a small new feature.

Class names assigned to schemas are now deduplicated to avoid collisions when distinct schemas PascalCase to the same identifier (e.g. `my-thing` and `MyThing`). Numbering is path-sorted so it stays stable across runs regardless of input scan order. The resolved names are also threaded through to decorator providers, so decorators that reference a class by name (e.g. `@Type(() => Foo)`, `@ApiExtraModels(...)`, `$ref: getSchemaPath(Foo)`) use the final identifier rather than the raw schema name.

Decorators emitted on classes and properties are now sorted by their source string before rendering, so output is stable regardless of the registration order of decorator providers (today's order is implicit, set by the module's `registerFunctionImplementations` argument list).

The test expectation generator now accepts a `oneOf` of constraint refs as an entity event's `data` property. When a constraint event narrows its `data` to a union of variants, the generated `expectMutated` call wraps the per-variant matcher objects in `expect.toBeOneOf([...])`, so any single variant matching the actual entity passes.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.