### PR TITLE
🔖 Prepare v0.23.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.23.0-beta.3 (2026-05-22)
+
 Features:
 
 - Support a `oneOf` of constraint refs as the `data` property of an entity mutated event. The generated expectation emits one matcher per variant inside `expect.toBeOneOf([...])`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.23.0-beta.2",
+  "version": "0.23.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "0.23.0-beta.2",
+      "version": "0.23.0-beta.3",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": ">= 0.25.0-beta.3 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "0.23.0-beta.2",
+  "version": "0.23.0-beta.3",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Features:

- Support a `oneOf` of constraint refs as the `data` property of an entity mutated event. The generated expectation emits one matcher per variant inside `expect.toBeOneOf([...])`.

Fixes:

- Deduplicate PascalCased schema names so colliding identifiers (e.g. two schemas resolving to the same class name) no longer produce invalid TypeScript output. Names assigned to schemas are also passed to decorator providers, so decorators referencing class names (e.g. `@Type(() => Foo)`) use the final identifier.
- Sort decorators by source before emitting them, ensuring stable output regardless of provider registration order.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~