### PR TITLE
🐛 Ensure every property has a class-validator decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Ensure every generated class property carries at least one `class-validator` decorator, so properties are not rejected under `whitelist` validation. Required, non-nullable properties without a matching validator fall back to `@Allow()`.
+
 ## v0.23.0-beta.3 (2026-05-22)
 
 Features:

--- a/src/code-generation/model-class/class-validator-decorators.spec.ts
+++ b/src/code-generation/model-class/class-validator-decorators.spec.ts
@@ -191,4 +191,75 @@ describe('makeClassValidatorDecorators', () => {
       '@IsUUID(undefined, { each: true })',
     ]);
   });
+
+  it('should add @IsArray() and @IsArray({ each: true }) for nested arrays', () => {
+    const property = makeProperty({
+      kind: 'array',
+      items: {
+        kind: 'array',
+        items: { kind: 'primitive', type: 'string' },
+        itemNullable: false,
+      },
+      itemNullable: false,
+    });
+
+    const actual = makeClassValidatorDecorators(SCHEMA, property, {}).map(
+      (d) => d.source,
+    );
+
+    expect(actual).toEqual(['@IsArray()', '@IsArray({ each: true })']);
+  });
+
+  it('should add @IsArray and @Equals(null, { each: true }) for arrays of null', () => {
+    const property = makeProperty({
+      kind: 'array',
+      items: { kind: 'null' },
+      itemNullable: false,
+    });
+
+    const actual = makeClassValidatorDecorators(SCHEMA, property, {}).map(
+      (d) => d.source,
+    );
+
+    expect(actual).toEqual(['@IsArray()', '@Equals(null, { each: true })']);
+  });
+
+  it('should add @Allow() fallback when no validator applies, only for required and non-nullable properties', () => {
+    // A ref to a union schema has no entry in the validator map, so the validators list ends up empty.
+    const UNION_PATH = '/test.json#/$defs/MyUnion';
+    const type: PropertyType = { kind: 'ref', ref: UNION_PATH };
+    const schemas: Record<string, Schema> = {
+      [UNION_PATH]: {
+        kind: 'union',
+        name: 'MyUnion',
+        path: UNION_PATH,
+        extensions: {},
+        types: [
+          { kind: 'primitive', type: 'string' },
+          { kind: 'primitive', type: 'integer' },
+        ],
+      },
+    };
+
+    const requiredNonNullable = makeClassValidatorDecorators(
+      SCHEMA,
+      makeProperty(type, { required: true, nullable: false }),
+      schemas,
+    ).map((d) => d.source);
+    expect(requiredNonNullable).toEqual(['@Allow()']);
+
+    const optional = makeClassValidatorDecorators(
+      SCHEMA,
+      makeProperty(type, { required: false, nullable: false }),
+      schemas,
+    );
+    expect(optional).toBeEmpty();
+
+    const nullable = makeClassValidatorDecorators(
+      SCHEMA,
+      makeProperty(type, { required: true, nullable: true }),
+      schemas,
+    );
+    expect(nullable).toBeEmpty();
+  });
 });

--- a/src/code-generation/model-class/class-validator-decorators.ts
+++ b/src/code-generation/model-class/class-validator-decorators.ts
@@ -1,4 +1,5 @@
 import type {
+  ConstPropertyType,
   EnumSchema,
   ObjectSchema,
   Property,
@@ -54,6 +55,23 @@ const KIND_TO_DECORATORS: Record<string, DecoratorDefinition[]> = {
     },
   ],
   datetime: [{ name: 'IsDate' }],
+  null: [
+    {
+      name: 'Equals',
+      source: (_, opts) => appendCall('@Equals', 'null', opts),
+    },
+  ],
+  const: [
+    {
+      name: 'Equals',
+      source: (t, opts) =>
+        appendCall(
+          '@Equals',
+          JSON.stringify((t as ConstPropertyType).value),
+          opts,
+        ),
+    },
+  ],
   enum: [
     {
       name: 'IsIn',
@@ -66,6 +84,9 @@ const KIND_TO_DECORATORS: Record<string, DecoratorDefinition[]> = {
     { name: 'ValidateNested', source: () => '@ValidateNested()' },
   ],
   map: [{ name: 'IsObject' }],
+  // Nested arrays: combined with the outer `@IsArray()`, this `@IsArray({ each: true })` checks that every item of
+  // the outer array is itself an array. Inner-item types are not validated.
+  array: [{ name: 'IsArray' }],
 };
 
 /**
@@ -91,42 +112,43 @@ export function makeClassValidatorDecorators(
   }
 
   const target = { schema, property };
-
-  if (property.type.kind === 'null') {
-    const decorators: TypeScriptDecorator[] = [];
-    addDecoratorToList(
-      decorators,
-      target,
-      'Equals',
-      CLASS_VALIDATOR_MODULE,
-      '@Equals(null)',
-    );
-    return decorators;
-  }
-
   const decorators: TypeScriptDecorator[] = [];
+  buildValidators(decorators, target, schemas);
 
-  if (property.type.kind === 'const') {
+  // Ensure the property carries at least one `class-validator` decorator so it isn't rejected under whitelist
+  // validation. Only applied to required, non-nullable properties, otherwise the Causa `@IsNullable` / `@AllowMissing`
+  // decorators already cover the property and `@Allow` would override their behavior.
+  if (decorators.length === 0 && property.required && !property.nullable) {
     addDecoratorToList(
       decorators,
       target,
-      'Equals',
+      'Allow',
       CLASS_VALIDATOR_MODULE,
-      appendCall('@Equals', JSON.stringify(property.type.value)),
+      '@Allow()',
     );
-    return decorators;
   }
 
+  return decorators;
+}
+
+/**
+ * Populates {@link decorators} with the `class-validator` / `class-transformer` decorators that apply to the given
+ * property's type. Returns early without throwing when the type cannot be mapped to any validator, leaving `decorators`
+ * partially populated.
+ */
+function buildValidators(
+  decorators: TypeScriptDecorator[],
+  target: { schema: ObjectSchema; property: Property },
+  schemas: Record<string, Schema>,
+): void {
+  const { property } = target;
   const isArray = property.type.kind === 'array';
   let singleType: PropertyType | Schema =
     property.type.kind === 'array' ? property.type.items : property.type;
-  if (singleType.kind === 'null') {
-    return decorators;
-  }
   if (singleType.kind === 'ref') {
     const resolved = schemas[singleType.ref];
     if (!resolved) {
-      return decorators;
+      return;
     }
     singleType = resolved;
   }
@@ -183,8 +205,6 @@ export function makeClassValidatorDecorators(
       `@Type(() => ${typeName})`,
     );
   }
-
-  return decorators;
 }
 
 /**


### PR DESCRIPTION
### 📝 Description of the PR

Every generated class property now ends up with at least one `class-validator` decorator, so properties are not silently rejected when validating with `whitelist` (`forbidNonWhitelisted`) enabled. Previously a handful of property shapes flowed through the generator without picking up any validator at all.

Required, non-nullable properties whose type cannot be mapped to a specific validator (unresolved refs, top-level unions) now fall back to `@Allow()`. Optional and nullable properties keep relying on the Causa `@AllowMissing` / `@IsNullable` decorators and do not get `@Allow()`, which would otherwise interfere with their behavior.

As part of the same pass, `null` and `const` property types are folded into the same kind-to-decorators mapping the other types use, so they emit consistent `@Equals(null)` / `@Equals(value)` decorators whether at the top level or as items inside an array. Nested arrays additionally emit a second `@IsArray({ each: true })` to validate that every item is itself an array.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.