### PR TITLE
🔖 Prepare v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.0.1 (2026-06-10)
+
 Fixes:
 
 - Alias all external-package imports in generated TypeScript code under a module-qualified name (e.g. `IsArray as _ClassValidatorIsArray`), so generated symbols can no longer clash with schema names or with identically-named symbols from other external modules.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes:

- Alias all external-package imports in generated TypeScript code under a module-qualified name (e.g. `IsArray as _ClassValidatorIsArray`), so generated symbols can no longer clash with schema names or with identically-named symbols from other external modules.