### PR TITLE
🔖 Prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.1.0 (2026-06-11)
+
 Features:
 
 - Generate event controllers from `serviceContainer.triggers` in the `typescriptNestjsController` generator. Other modules can contribute method decorators by implementing the new `ModelGenerateTypeScriptTriggerDecorators` function.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Generate event controllers from `serviceContainer.triggers` in the `typescriptNestjsController` generator. Other modules can contribute method decorators by implementing the new `ModelGenerateTypeScriptTriggerDecorators` function.
- Clear the `typescriptNestjsController` output directory before generating files.
- Decorate generated API controller methods with `@Public()` from `@causa/runtime/nestjs` when the OpenAPI operation declares an empty `security` array.

Fixes:

- Define the `design:paramtypes` metadata for generated API and event controller methods if it is not already emitted by the compiler.