### PR TITLE
💚 Remove the Causa dependencies flattening workaround in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
             .causa/node_modules
           key: ${{ runner.os }}-${{ hashFiles('causa.yaml') }}
 
-      - name: 🐛 Flatten Causa dependencies
-        run: cs init || cd .causa && npm dedup
-
       - name: 🎉 Initialize
         run: cs init
 
@@ -79,9 +76,6 @@ jobs:
             .causa/package*
             .causa/node_modules
           key: ${{ runner.os }}-${{ hashFiles('causa.yaml') }}
-
-      - name: 🐛 Flatten Causa dependencies
-        run: cs init || cd .causa && npm dedup
 
       - name: 🎉 Initialize
         run: cs init


### PR DESCRIPTION
### 📝 Description of the PR

Removes the workaround step that flattened and deduplicated Causa dependencies before initializing the workspace in both CI jobs. This step is no longer necessary, so dropping it simplifies the CI workflow and removes a redundant `cs init` invocation.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- ~📝 Documentation has been updated.~