### PR TITLE
✨ Improve npm dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 Features:
 
 - Default to Node.js `24` (instead of `20`) when building a TypeScript service container Docker image and `javascript.node.version` is set to `latest`.
+- Do not upgrade dependencies to deprecated versions when running `ProjectDependenciesUpdate`.
+
+Chores:
+
+- Defer loading of heavy dependencies (`npm-check-updates`) during function registration.
 
 ## v1.1.0 (2026-06-11)
 

--- a/src/functions/project/dependencies-update-javascript.call.ts
+++ b/src/functions/project/dependencies-update-javascript.call.ts
@@ -1,0 +1,106 @@
+import type { WorkspaceContext } from '@causa/workspace';
+import { GitService } from '@causa/workspace-core/services';
+import { run } from 'npm-check-updates';
+import { join } from 'path';
+import type { TypeScriptConfiguration } from '../../configurations/index.js';
+import { NpmService } from '../../services/index.js';
+import { PACKAGE_FILE, PACKAGE_LOCK_FILE } from '../../utils.js';
+import type { ProjectDependenciesUpdateForJavaScript } from './dependencies-update-javascript.js';
+
+/**
+ * Checks whether the package files have uncommitted changes.
+ *
+ * @param context The workspace context.
+ * @returns `true` if the package files have uncommitted changes.
+ */
+async function hasUncommittedPackageChanges(
+  context: WorkspaceContext,
+): Promise<boolean> {
+  const projectPath = context.getProjectPathOrThrow();
+  const packageFiles = [PACKAGE_FILE, PACKAGE_LOCK_FILE].map((file) =>
+    join(projectPath, file),
+  );
+
+  const changedFiles = await context.service(GitService).filesDiff({
+    commits: ['HEAD'],
+    paths: packageFiles,
+  });
+
+  return changedFiles.length > 0;
+}
+
+/**
+ * Runs `npm-check-updates` to look for dependency updates, possibly writing the `package.json` in the process.
+ *
+ * @param context The workspace context.
+ * @returns The upgraded dependencies, as a map of dependency name to new version.
+ */
+async function lookForUpdates(
+  context: WorkspaceContext,
+): Promise<Record<string, string>> {
+  context.logger.info(`⬆️ Updating dependencies in 'package.json'.`);
+
+  const projectPath = context.getProjectPathOrThrow();
+  const conf = context.asConfiguration<TypeScriptConfiguration>();
+  const defaultTarget =
+    conf.get('javascript.dependencies.update.defaultTarget') ?? 'latest';
+  const packageTargets =
+    conf.get('javascript.dependencies.update.packageTargets') ?? {};
+
+  const previousEnv = { ...process.env };
+  const environment = await context.service(NpmService).environment;
+  process.env = { ...previousEnv, ...environment };
+
+  const upgrades = await run({
+    cwd: projectPath,
+    target: (dependencyName) => packageTargets[dependencyName] ?? defaultTarget,
+    jsonUpgraded: true,
+    upgrade: true,
+    deprecated: false,
+  });
+
+  process.env = previousEnv;
+
+  return (upgrades as any) ?? {};
+}
+
+export default async function call(
+  this: ProjectDependenciesUpdateForJavaScript,
+): Promise<boolean> {
+  const projectPath = this._context.getProjectPathOrThrow();
+
+  if (await hasUncommittedPackageChanges(this._context)) {
+    throw new Error(
+      `The package file(s) contain uncommitted changes but would be modified during the update. Changes should be committed or stashed before running the update.`,
+    );
+  }
+
+  const upgrades = await lookForUpdates(this._context);
+  const hasDirectUpdates = Object.keys(upgrades).length > 0;
+  if (hasDirectUpdates) {
+    this._context.logger.info(
+      `⬆️ Upgraded the following dependencies:\n${Object.entries(upgrades)
+        .map(([name, version]) => `  ${name} => ${version}`)
+        .join('\n')}.`,
+    );
+  }
+
+  this._context.logger.info(`⬆️ Running 'npm update'.`);
+  await this._context
+    .service(NpmService)
+    .update({ workingDirectory: projectPath });
+
+  if (!hasDirectUpdates) {
+    const hasIndirectUpdates = await hasUncommittedPackageChanges(
+      this._context,
+    );
+    if (!hasIndirectUpdates) {
+      this._context.logger.info(`✅ No dependency to update.`);
+      return false;
+    }
+
+    this._context.logger.info(`⬆️ Indirect dependencies have been updated.`);
+  }
+
+  return true;
+}

--- a/src/functions/project/dependencies-update-javascript.spec.ts
+++ b/src/functions/project/dependencies-update-javascript.spec.ts
@@ -106,6 +106,7 @@ describe('ProjectDependenciesUpdateForJavaScript', () => {
       target: expect.any(Function),
       jsonUpgraded: true,
       upgrade: true,
+      deprecated: false,
     });
     const actualTarget = (ncuRunMock.mock.calls[0][0] as any).target;
     expect(actualTarget('is-even')).toEqual('minor');
@@ -133,6 +134,7 @@ describe('ProjectDependenciesUpdateForJavaScript', () => {
       target: expect.any(Function),
       jsonUpgraded: true,
       upgrade: true,
+      deprecated: false,
     });
     expect(npmService.update).toHaveBeenCalledExactlyOnceWith({
       workingDirectory: tmpDir,
@@ -155,6 +157,7 @@ describe('ProjectDependenciesUpdateForJavaScript', () => {
       target: expect.any(Function),
       jsonUpgraded: true,
       upgrade: true,
+      deprecated: false,
     });
     expect(npmService.update).toHaveBeenCalledExactlyOnceWith({
       workingDirectory: tmpDir,

--- a/src/functions/project/dependencies-update-javascript.ts
+++ b/src/functions/project/dependencies-update-javascript.ts
@@ -1,10 +1,5 @@
+import { callDeferred } from '@causa/workspace';
 import { ProjectDependenciesUpdate } from '@causa/workspace-core';
-import { GitService } from '@causa/workspace-core/services';
-import { run } from 'npm-check-updates';
-import { join } from 'path';
-import type { TypeScriptConfiguration } from '../../configurations/index.js';
-import { NpmService } from '../../services/index.js';
-import { PACKAGE_FILE, PACKAGE_LOCK_FILE } from '../../utils.js';
 
 /**
  * Implements the {@link ProjectDependenciesUpdate} function for JavaScript and TypeScript projects.
@@ -13,97 +8,12 @@ import { PACKAGE_FILE, PACKAGE_LOCK_FILE } from '../../utils.js';
  */
 export class ProjectDependenciesUpdateForJavaScript extends ProjectDependenciesUpdate {
   async _call(): Promise<boolean> {
-    const projectPath = this._context.getProjectPathOrThrow();
-
-    if (await this.hasUncommittedPackageChanges()) {
-      throw new Error(
-        `The package file(s) contain uncommitted changes but would be modified during the update. Changes should be committed or stashed before running the update.`,
-      );
-    }
-
-    const upgrades = await this.lookForUpdates();
-    const hasDirectUpdates = Object.keys(upgrades).length > 0;
-    if (hasDirectUpdates) {
-      this._context.logger.info(
-        `⬆️ Upgraded the following dependencies:\n${Object.entries(upgrades)
-          .map(([name, version]) => `  ${name} => ${version}`)
-          .join('\n')}.`,
-      );
-    }
-
-    this._context.logger.info(`⬆️ Running 'npm update'.`);
-    await this._context
-      .service(NpmService)
-      .update({ workingDirectory: projectPath });
-
-    if (!hasDirectUpdates) {
-      const hasIndirectUpdates = await this.hasUncommittedPackageChanges();
-      if (!hasIndirectUpdates) {
-        this._context.logger.info(`✅ No dependency to update.`);
-        return false;
-      }
-
-      this._context.logger.info(`⬆️ Indirect dependencies have been updated.`);
-    }
-
-    return true;
+    return await callDeferred(this, import.meta.url);
   }
 
   _supports(): boolean {
     return ['javascript', 'typescript'].includes(
       this._context.get('project.language') ?? '',
     );
-  }
-
-  /**
-   * Checks whether the package files have uncommitted changes.
-   *
-   * @returns `true` if the package files have uncommitted changes.
-   */
-  private async hasUncommittedPackageChanges(): Promise<boolean> {
-    const projectPath = this._context.getProjectPathOrThrow();
-    const packageFiles = [PACKAGE_FILE, PACKAGE_LOCK_FILE].map((file) =>
-      join(projectPath, file),
-    );
-
-    const changedFiles = await this._context.service(GitService).filesDiff({
-      commits: ['HEAD'],
-      paths: packageFiles,
-    });
-
-    return changedFiles.length > 0;
-  }
-
-  /**
-   * Runs `npm-check-updates` to look for dependency updates, possibly writing the `package.json` in the process.
-   *
-   * @returns The upgraded dependencies, as a map of dependency name to new version.
-   */
-  private async lookForUpdates(): Promise<Record<string, string>> {
-    this._context.logger.info(`⬆️ Updating dependencies in 'package.json'.`);
-
-    const projectPath = this._context.getProjectPathOrThrow();
-    const conf = this._context.asConfiguration<TypeScriptConfiguration>();
-    const defaultTarget =
-      conf.get('javascript.dependencies.update.defaultTarget') ?? 'latest';
-    const packageTargets =
-      conf.get('javascript.dependencies.update.packageTargets') ?? {};
-
-    const previousEnv = { ...process.env };
-    const environment = await this._context.service(NpmService).environment;
-    process.env = { ...previousEnv, ...environment };
-
-    const upgrades = await run({
-      cwd: projectPath,
-      target: (dependencyName) =>
-        packageTargets[dependencyName] ?? defaultTarget,
-      jsonUpgraded: true,
-      upgrade: true,
-      deprecated: false,
-    });
-
-    process.env = previousEnv;
-
-    return (upgrades as any) ?? {};
   }
 }

--- a/src/functions/project/dependencies-update-javascript.ts
+++ b/src/functions/project/dependencies-update-javascript.ts
@@ -99,6 +99,7 @@ export class ProjectDependenciesUpdateForJavaScript extends ProjectDependenciesU
         packageTargets[dependencyName] ?? defaultTarget,
       jsonUpgraded: true,
       upgrade: true,
+      deprecated: false,
     });
 
     process.env = previousEnv;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,7 +2,7 @@ import module from 'module';
 
 const require = module.createRequire(import.meta.url);
 
-const heavyModules = ['@scalar/'];
+const heavyModules = ['@scalar/', 'npm-check-updates'];
 
 describe('registerFunctions', () => {
   function getLoadedModules(): string[] {


### PR DESCRIPTION
### 📝 Description of the PR

Improves how JavaScript and TypeScript dependencies are updated by `ProjectDependenciesUpdate`. Deprecated versions are now excluded, so dependencies are no longer upgraded to a release that has since been marked deprecated on the registry.

The implementation of `ProjectDependenciesUpdateForJavaScript` is also moved to a deferred call file, so the heavy `npm-check-updates` module is only loaded when the function actually runs, rather than during function registration.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.