### PR TITLE
🗑️ Deprecate the security check implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Features:
 Chores:
 
 - Defer loading of heavy dependencies (`npm-check-updates`) during function registration.
+- Deprecate the security check implementation.
 
 ## v1.1.0 (2026-06-11)
 

--- a/src/functions/project/security-check.ts
+++ b/src/functions/project/security-check.ts
@@ -22,6 +22,10 @@ const CONTAINER_CODE_LOCATION = '/workdir';
  */
 export class ProjectSecurityCheckForJavaScript extends ProjectSecurityCheck {
   async _call(): Promise<void> {
+    this._context.logger.warn(
+      '⚠️ The security check for JavaScript and TypeScript projects in its current form is deprecated and will be removed in a future release.',
+    );
+
     const projectPath = this._context.getProjectPathOrThrow();
     const projectName = this._context.get('project.name');
 


### PR DESCRIPTION
### 📝 Description of the PR

The security check function for JavaScript and TypeScript projects (`ProjectSecurityCheckForJavaScript`, running `njsscan`) is now deprecated. A warning is logged when the check runs, indicating it will be removed in a future release in its current form. This change is non-breaking: the check still runs as before.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
