### PR TITLE
✨ Support running npm commands in sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 - Default to Node.js `24` (instead of `20`) when building a TypeScript service container Docker image and `javascript.node.version` is set to `latest`.
 - Do not upgrade dependencies to deprecated versions when running `ProjectDependenciesUpdate`.
+- Support running npm commands in sandboxes using the `javascript.npm.sandbox` configuration.
 
 Chores:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ Add `@causa/workspace-typescript` to your Causa configuration in `causa.modules`
 
 For all the configuration in your Causa files related to TypeScript (but also JavaScript) look at [the schema for the `TypeScriptConfiguration`](./src/configurations/typescript.ts).
 
+### Sandboxing `npm` commands
+
+`npm` commands can be run in sandboxes defined under the `causa.sandboxes` configuration. Sandboxes are selected per command using the `javascript.npm.sandbox` configuration:
+
+```yaml
+javascript:
+  npm:
+    sandbox:
+      # The sandbox used when no command-specific sandbox matches.
+      # Optional: if there is no match and no default, the command is not sandboxed.
+      default: mySandbox
+      # The sandbox used when running `npm ci`. Keys are npm command names.
+      ci: ciSandbox
+      # npm scripts are matched using `run <script>`, e.g. for `npm run build`.
+      run build: buildSandbox
+```
+
 ## ✨ Supported project types and commands
 
 Projects supported by this module must have `typescript` (or in some cases `javascript` is enough) as their `project.language`. The following Causa `project.type`s are supported:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": "^1.0.1",
-        "@causa/workspace-core": "^1.1.0",
+        "@causa/workspace-core": "^1.2.0",
         "archiver": "^8.0.0",
         "audit-ci": "^7.1.0",
         "change-case": "^5.4.4",
@@ -47,6 +47,34 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@anthropic-ai/sandbox-runtime": {
+      "version": "0.0.61",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.61.tgz",
+      "integrity": "sha512-5atex1pnNZW/Ba83376+m83FFIbWrqzoCKCxeC4Kx7YF9El/50WBW3zAbDxYONP2k1SvK9XL07s5EZC6JhQ2jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pondwader/socks5-server": "^1.0.10",
+        "commander": "^12.1.0",
+        "node-forge": "^1.4.0",
+        "shell-quote": "^1.8.4",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "srt": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sandbox-runtime/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -603,16 +631,18 @@
       }
     },
     "node_modules/@causa/workspace-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@causa/workspace-core/-/workspace-core-1.1.0.tgz",
-      "integrity": "sha512-W5YGK/1hNO6U4apUsF+PBIdNDSq69CNzWoy0iIBm6B0/2nd/rk4Qrd6T07EdVO3l3QLQHb8ryp/X330W0xovSw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@causa/workspace-core/-/workspace-core-1.2.0.tgz",
+      "integrity": "sha512-BRkQaQ5KlnQOVpTjcoxs55KNPkPyibkK6erYzLS5nYx3FRhQIZHLPej1zFCzUyiQS2qAod7cCQY117hsPkPKSg==",
       "license": "ISC",
       "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "0.0.61",
         "@causa/cli": "^1.0.0",
-        "@causa/workspace": "^1.0.0",
-        "@scalar/json-magic": "^0.12.15",
-        "@scalar/openapi-parser": "^0.28.6",
+        "@causa/workspace": "^1.0.1",
+        "@scalar/json-magic": "^0.12.17",
+        "@scalar/openapi-parser": "^0.28.8",
         "ajv": "^8.20.0",
+        "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "expect": "^30.4.1",
         "globby": "^16.2.0",
@@ -1649,22 +1679,28 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@pondwader/socks5-server": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
+      "integrity": "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==",
+      "license": "MIT"
+    },
     "node_modules/@scalar/helpers": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.2.tgz",
-      "integrity": "sha512-qNbqUjSB3S4Gr4A0oANcm5G1Ip+EqBxICYKhe9YzmnaBpbmW6shxqpiivApTvvuDf+uIhR3uMwWyVQbYcGLsxA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.9.0.tgz",
+      "integrity": "sha512-M34CLRCttqC1bXthI/QSzQj0s5C6nrU2PFWf/vOT3RpycbiGDGQbqR+5RfFzpOIQvRqbHfNdcRbeiZBw+vCbkQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@scalar/json-magic": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.16.tgz",
-      "integrity": "sha512-w8cDbZhHCzmIblWx92IVWoAXsbI4Fz3m++jiBANTSO1hgphF6UqEPQiCt3wnMPaxaanjMQxjS/iBk1UGXR2EGA==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/@scalar/json-magic/-/json-magic-0.12.17.tgz",
+      "integrity": "sha512-Vw2nrUDIjhvMP6vxFtkiiFlabJ6SyTtfn1BsOxgnr1hIB+/rkngMguiDzl5em21VjyfFGIoADia+QWKM2hdcdA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.8.2",
+        "@scalar/helpers": "0.9.0",
         "pathe": "^2.0.3",
         "yaml": "^2.8.3"
       },
@@ -1673,13 +1709,13 @@
       }
     },
     "node_modules/@scalar/openapi-parser": {
-      "version": "0.28.7",
-      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.7.tgz",
-      "integrity": "sha512-E6beEdTsJxUStxOmY1knQvSNJq6LTiXOsRX2WTrfmU6d/kiATn6IKkAU0kXtAZkaYCGU4UCEmBFHCMmNKn0JLA==",
+      "version": "0.28.8",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-parser/-/openapi-parser-0.28.8.tgz",
+      "integrity": "sha512-BO98D3TLfKNL80UnE1sIAmI6DQRmOaH0AHnlAooTn1sQjNbRDaeHyRO53EEjo7HjFEdHeQtiRzoXmMB4jvt8AA==",
       "license": "MIT",
       "dependencies": {
-        "@scalar/helpers": "0.8.2",
-        "@scalar/json-magic": "0.12.16",
+        "@scalar/helpers": "0.9.0",
+        "@scalar/json-magic": "0.12.17",
         "@scalar/openapi-types": "0.9.1",
         "@scalar/openapi-upgrader": "0.2.9",
         "ajv": "^8.17.1",
@@ -6166,6 +6202,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7185,6 +7230,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8045,6 +8102,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -71,5 +71,10 @@
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0"
+  },
+  "allowScripts": {
+    "@swc/core": true,
+    "fsevents": true,
+    "unrs-resolver": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@causa/workspace": "^1.0.1",
-    "@causa/workspace-core": "^1.1.0",
+    "@causa/workspace-core": "^1.2.0",
     "archiver": "^8.0.0",
     "audit-ci": "^7.1.0",
     "change-case": "^5.4.4",

--- a/src/configurations/generated.ts
+++ b/src/configurations/generated.ts
@@ -259,6 +259,17 @@ export class Npm {
   @IsString()
   readonly packDestination?: string;
 
+  /**
+   * The sandbox profiles to use when running npm commands.
+   * Keys are npm command names (e.g. `build`, `ci`), or `run <script>` for npm scripts.
+   * Values are sandbox profile keys defined under the `causa.sandboxes` configuration.
+   * The `default` key is used when no command-specific sandbox matches.
+   * If no command matches and no default is set, the command is not sandboxed.
+   */
+  @AllowMissing()
+  @IsObject()
+  readonly sandbox?: Record<string, string>;
+
   [key: string]: any;
 }
 

--- a/src/configurations/schemas/typescript.yaml
+++ b/src/configurations/schemas/typescript.yaml
@@ -34,6 +34,17 @@ properties:
               The destination directory for built packages, relative to the project's root.
               This is used when building JavaScript / TypeScript package artefacts.
 
+          sandbox:
+            type: object
+            description: |-
+              The sandbox profiles to use when running npm commands.
+              Keys are npm command names (e.g. `ci`), or `run <script>` for npm scripts.
+              Values are sandbox profile keys defined under the `causa.sandboxes` configuration.
+              The `default` key is used when no command-specific sandbox matches.
+              If no command matches and no default is set, the command is not sandboxed.
+            additionalProperties:
+              type: string
+
       node:
         title: JavaScriptNode
         type: object

--- a/src/services/npm.spec.ts
+++ b/src/services/npm.spec.ts
@@ -79,6 +79,84 @@ describe('NpmService', () => {
     });
   });
 
+  describe('sandbox', () => {
+    let processService: ProcessService;
+
+    beforeEach(() => {
+      ({ context } = createContext({
+        configuration: {
+          workspace: { name: '🏷️' },
+          javascript: {
+            npm: {
+              sandbox: {
+                default: 'defaultSandbox',
+                ci: 'ciSandbox',
+                'run build': 'buildSandbox',
+              },
+            },
+          },
+        },
+      }));
+      service = context.service(NpmService);
+      processService = context.service(ProcessService);
+      jest
+        .spyOn(processService, 'spawn')
+        .mockReturnValue({ result: Promise.resolve({ code: 0 }) } as any);
+    });
+
+    it('should run the command in the sandbox matching the command name', async () => {
+      await service.npm('ci', []);
+
+      expect(processService.spawn).toHaveBeenCalledExactlyOnceWith(
+        'npm',
+        ['ci'],
+        expect.objectContaining({ sandbox: 'ciSandbox' }),
+      );
+    });
+
+    it('should run the script in the sandbox matching `run <script>`', async () => {
+      await service.npm('run-script', ['build', '--', '--arg']);
+
+      expect(processService.spawn).toHaveBeenCalledExactlyOnceWith(
+        'npm',
+        ['run-script', 'build', '--', '--arg'],
+        expect.objectContaining({ sandbox: 'buildSandbox' }),
+      );
+    });
+
+    it('should fall back to the default sandbox when no command matches', async () => {
+      await service.npm('publish', []);
+
+      expect(processService.spawn).toHaveBeenCalledExactlyOnceWith(
+        'npm',
+        ['publish'],
+        expect.objectContaining({ sandbox: 'defaultSandbox' }),
+      );
+    });
+
+    it('should not sandbox when no command matches and no default is set', async () => {
+      ({ context } = createContext({
+        configuration: {
+          workspace: { name: '🏷️' },
+          javascript: { npm: { sandbox: { ci: 'ciSandbox' } } },
+        },
+      }));
+      service = context.service(NpmService);
+      processService = context.service(ProcessService);
+      jest
+        .spyOn(processService, 'spawn')
+        .mockReturnValue({ result: Promise.resolve({ code: 0 }) } as any);
+
+      await service.npm('publish', []);
+
+      expect(processService.spawn).toHaveBeenCalledExactlyOnceWith(
+        'npm',
+        ['publish'],
+        expect.objectContaining({ sandbox: undefined }),
+      );
+    });
+  });
+
   describe('build', () => {
     it('should run the build command', async () => {
       jest.spyOn(service, 'npm').mockResolvedValueOnce({ code: 0 });

--- a/src/services/npm.ts
+++ b/src/services/npm.ts
@@ -29,10 +29,18 @@ export class NpmService {
    */
   readonly requiredVersion: string;
 
+  /**
+   * The mapping of npm commands to sandbox profile keys, read from the `javascript.npm.sandbox` configuration.
+   * Keys are npm command names (e.g. `build`, `ci`), or `run <script>` for npm scripts.
+   * The `default` key is used when no command-specific sandbox matches.
+   */
+  readonly sandboxes: Record<string, string>;
+
   constructor(context: WorkspaceContext) {
     this.processService = context.service(ProcessService);
     this.environment = context.getAndRender('javascript.npm.environment');
     this.requiredVersion = context.get('javascript.npm.version') ?? 'latest';
+    this.sandboxes = context.get('javascript.npm.sandbox') ?? {};
   }
 
   /**
@@ -163,10 +171,13 @@ export class NpmService {
     await this.checkNpmVersion();
 
     const defaultEnvironment = (await this.environment) ?? {};
+    const sandboxKey = command === 'run-script' ? `run ${args[0]}` : command;
+    const sandbox = this.sandboxes[sandboxKey] ?? this.sandboxes.default;
 
     try {
-      const p = this.processService.spawn('npm', [command, ...args], {
+      const p = await this.processService.spawn('npm', [command, ...args], {
         capture: { stderr: true },
+        sandbox,
         ...options,
         environment: options.environment ?? {
           ...process.env,


### PR DESCRIPTION
### 📝 Description of the PR

npm commands run by the module can now be executed inside sandboxes. Sandboxes are defined under the `causa.sandboxes` configuration (handled by the core module) and selected per command through the new optional `javascript.npm.sandbox` configuration. The matching sandbox is looked up by npm command name (e.g. `ci`), with npm scripts matched as `run <script>` (e.g. `run build`). A `default` sandbox can be set as a fallback; when no command matches and no default is set, the command runs without a sandbox.

This relies on the sandboxing support introduced in `@causa/workspace-core`, so its dependency is bumped to `^1.2.0`.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
