### PR TITLE
🔖 Prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.2.0 (2026-06-29)
+
 Features:
 
 - Default to Node.js `24` (instead of `20`) when building a TypeScript service container Docker image and `javascript.node.version` is set to `latest`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/workspace-typescript",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@causa/workspace": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/workspace-typescript",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "The Causa workspace module providing functionalities for projects coded in TypeScript.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Features:

- Default to Node.js `24` (instead of `20`) when building a TypeScript service container Docker image and `javascript.node.version` is set to `latest`.
- Do not upgrade dependencies to deprecated versions when running `ProjectDependenciesUpdate`.
- Support running npm commands in sandboxes using the `javascript.npm.sandbox` configuration.

Chores:

- Defer loading of heavy dependencies (`npm-check-updates`) during function registration.
- Deprecate the security check implementation.